### PR TITLE
Remove --repository Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ You can use `changelog-updater` by running the `update` command with the followi
 ```php
 php changelog-updater update \
 --release-notes="# Added" \
---repository="https://github.com/stefanzweifel/php-changelog-updater" \
 --latest-version="v1.0.0" \
---path-to-changelog="CHANGELOG.md" \
---release-date="2021-08-07"
---write
+--release-date="2021-08-07" \
+--write \ 
+--path-to-changelog="CHANGELOG.md"
 ```
 
 Note that the CHANGELOG MUST to follow the "[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)"-format. In detail, the CLI looks for a second level "Unreleased"-heading with a link. The link MUST to point to the compare view of the latest version and `HEAD`.
@@ -60,9 +59,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `--release-notes`
 **Required**. The release notes you want to add to your CHANGELOG. Should be markdown.
 
-### `--repository`
-**Required**. The URL which points to your repository. The URL will be used to update the "Unreleased" heading in your CHANGELOG.
-
 ### `--latest-version`
 **Required**. Semantic version number of the latest release. The value will be used as the heading text and as a parameter in the compare URL.
 
@@ -71,9 +67,8 @@ Example: `v1.0.0`
 ### `--release-date`
 **Required.** The date the latest version has been released. The value will be used in the release heading.
 
-
 ### `--path-to-changelog`
-Default `CHANGELOG.md`. Path to CHANGELOG.md file.
+Defaults to `CHANGELOG.md`. Path to CHANGELOG.md file.
 
 ### `--write`
 Optional. Write the changes to `CHANGELOG.md` or to the value of `--path-to-changelog`.

--- a/app/Actions/AddReleaseNotesToChangelog.php
+++ b/app/Actions/AddReleaseNotesToChangelog.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Str;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
-use League\CommonMark\Node\Node;
 use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Parser\MarkdownParser;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;

--- a/app/Actions/AddReleaseNotesToChangelog.php
+++ b/app/Actions/AddReleaseNotesToChangelog.php
@@ -45,17 +45,18 @@ class AddReleaseNotesToChangelog
      * @param string $releaseNotes
      * @param string $latestVersion
      * @param string $releaseDate
-     * @param string $repositoryUrl
      * @return RenderedContentInterface
      * @throws \Throwable
      */
-    public function execute(string $originalChangelog, string $releaseNotes, string $latestVersion, string $releaseDate, string $repositoryUrl): RenderedContentInterface
+    public function execute(string $originalChangelog, string $releaseNotes, string $latestVersion, string $releaseDate): RenderedContentInterface
     {
         $changelog = $this->parser->parse($originalChangelog);
 
         $unreleasedHeading = $this->findUnreleasedHeading->find($changelog);
 
         $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($unreleasedHeading);
+
+        $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($unreleasedHeading);
 
         $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $latestVersion, 'HEAD');
 
@@ -102,5 +103,16 @@ class AddReleaseNotesToChangelog
             ->afterLast('/')
             ->explode('...')
             ->first();
+    }
+
+    private function getRepositoryUrlFromUnreleasedHeading(Heading $unreleasedHeading): string
+    {
+        /** @var Link $linkNode */
+        $linkNode = $unreleasedHeading->firstChild();
+
+        throw_if($linkNode === null, new \LogicException("Can not find link node in unreleased heading."));
+
+        return (string) Str::of($linkNode->getUrl())
+            ->before('/compare');
     }
 }

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -13,7 +13,6 @@ class UpdateCommand extends Command
 {
     protected $signature = 'update
         {--release-notes= : Markdown Release Notes to be added to the CHANGELOG}
-        {--repository= : Web URL pointing to the repository}
         {--latest-version= : The version the CHANGELOG should be updated too}
         {--release-date= : Date when latest version has been released}
         {--path-to-changelog=CHANGELOG.md : Path to changelog markdown file to be updated}
@@ -28,7 +27,6 @@ class UpdateCommand extends Command
     public function handle(AddReleaseNotesToChangelog $addReleaseNotesToChangelog)
     {
         $releaseNotes = $this->option('release-notes');
-        $repositoryUrl = $this->option('repository');
         $latestVersion = $this->option('latest-version');
         $releaseDate = $this->option('release-date');
         $pathToChangelog = $this->option('path-to-changelog');
@@ -40,8 +38,7 @@ class UpdateCommand extends Command
             originalChangelog: $changelog,
             releaseNotes: $releaseNotes,
             latestVersion: $latestVersion,
-            releaseDate: $releaseDate,
-            repositoryUrl: $repositoryUrl
+            releaseDate: $releaseDate
         );
 
         $this->info($updatedChangelog->getContent());

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -15,7 +15,6 @@ it('places given release notes in correct position in given markdown changelog',
         ### Removes
         - Remove Feature D
         MD,
-        '--repository' => 'https://github.com/org/repo',
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
         '--release-date' => '2021-02-01',


### PR DESCRIPTION
Make the --repository option obsolete by parsing the value out of the link inside the unreleased heading.