### PR TITLE
Paste Release Notes at the top if no Unreleased Heading can be found

### DIFF
--- a/app/Actions/AddReleaseNotesToChangelog.php
+++ b/app/Actions/AddReleaseNotesToChangelog.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\CreateNewReleaseHeading;
+use App\FindFirstSecondLevelHeading;
 use App\FindPreviousVersionHeading;
 use App\FindUnreleasedHeading;
 use App\GenerateCompareUrl;
@@ -12,6 +13,9 @@ use Illuminate\Support\Str;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Node\Inline\Text;
+use League\CommonMark\Node\Node;
 use League\CommonMark\Output\RenderedContentInterface;
 use League\CommonMark\Parser\MarkdownParser;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
@@ -53,27 +57,11 @@ class AddReleaseNotesToChangelog
 
         $unreleasedHeading = $this->findUnreleasedHeading->find($changelog);
 
-        $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($unreleasedHeading);
-        $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($unreleasedHeading);
-        $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $latestVersion, 'HEAD');
+        if ($unreleasedHeading) {
+            return $this->pasteReleaseNotesBasedOnUnreleasedHeading($unreleasedHeading, $latestVersion, $releaseDate, $releaseNotes, $changelog);
+        }
+        return $this->pasteReleaseNotesAtTheTop($latestVersion, $releaseNotes, $releaseDate, $changelog);
 
-        $link = $this->getLinkNodeFromHeading($unreleasedHeading);
-        $link->setUrl($updatedUrl);
-
-        // Create new Heading containing the new version number
-        $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $releaseDate);
-
-        // Prepend the new Release Heading to the Release Notes
-        $parsedReleaseNotes = $this->parser->parse($releaseNotes);
-        $parsedReleaseNotes->prependChild($newReleaseHeading);
-
-        // Find the Heading of the previous Version
-        $previousVersionHeading = $this->findPreviousVersionHeading->find($changelog, $previousVersion);
-
-        // Insert the newest Release Notes before the previous Release Heading
-        $previousVersionHeading?->insertBefore($parsedReleaseNotes);
-
-        return $this->renderer->renderDocument($changelog);
     }
 
     /**
@@ -118,5 +106,67 @@ class AddReleaseNotesToChangelog
         throw_if($linkNode === null, new \LogicException("Can not find link node in unreleased heading."));
 
         return $linkNode;
+    }
+
+    /**
+     * @param Node|null $unreleasedHeading
+     * @param string $latestVersion
+     * @param string $releaseDate
+     * @param string $releaseNotes
+     * @param Document $changelog
+     * @return RenderedContentInterface
+     * @throws \Throwable
+     */
+    protected function pasteReleaseNotesBasedOnUnreleasedHeading(?Node $unreleasedHeading, string $latestVersion, string $releaseDate, string $releaseNotes, Document $changelog): RenderedContentInterface
+    {
+        $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($unreleasedHeading);
+        $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($unreleasedHeading);
+        $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $latestVersion, 'HEAD');
+
+        $link = $this->getLinkNodeFromHeading($unreleasedHeading);
+        $link->setUrl($updatedUrl);
+
+        // Create new Heading containing the new version number
+        $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $releaseDate);
+
+        // Prepend the new Release Heading to the Release Notes
+        $parsedReleaseNotes = $this->parser->parse($releaseNotes);
+        $parsedReleaseNotes->prependChild($newReleaseHeading);
+
+        // Find the Heading of the previous Version
+        $previousVersionHeading = $this->findPreviousVersionHeading->find($changelog, $previousVersion);
+
+        // Insert the newest Release Notes before the previous Release Heading
+        $previousVersionHeading?->insertBefore($parsedReleaseNotes);
+
+        return $this->renderer->renderDocument($changelog);
+    }
+
+    /**
+     * @param string $latestVersion
+     * @param string $releaseNotes
+     * @param string $releaseDate
+     * @param Document $changelog
+     * @return RenderedContentInterface
+     */
+    protected function pasteReleaseNotesAtTheTop(string $latestVersion, string $releaseNotes, string $releaseDate, Document $changelog): RenderedContentInterface
+    {
+        // Create new Heading containing the new version number
+        $newReleaseHeading =  tap(new Heading(2), function ($heading) use ($latestVersion, $releaseDate) {
+            $heading->appendChild(new Text($latestVersion));
+            $heading->appendChild(new Text(" - {$releaseDate}"));
+        });
+
+        // Prepend the new Release Heading to the Release Notes
+        $parsedReleaseNotes = $this->parser->parse($releaseNotes);
+        $parsedReleaseNotes->prependChild($newReleaseHeading);
+
+        // Find the Heading of the previous Version
+        $previousVersionHeading = app(FindFirstSecondLevelHeading::class)->find($changelog);
+
+        // Insert the newest Release Notes before the previous Release Heading
+        $previousVersionHeading?->insertBefore($parsedReleaseNotes);
+
+        return $this->renderer->renderDocument($changelog);
     }
 }

--- a/app/FindFirstSecondLevelHeading.php
+++ b/app/FindFirstSecondLevelHeading.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use App\QueryExpressions\HeadingLevel;
+use App\QueryExpressions\HeadingText;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Node\Query;
+
+class FindFirstSecondLevelHeading
+{
+    /**
+     * @param Document $document
+     * @return Node|null
+     */
+    public function find(Document $document): ?Node
+    {
+        return (new Query())
+            ->where(Query::type(Heading::class))
+            ->andWhere(new HeadingLevel(2))
+            ->findOne($document);
+    }
+}

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -76,3 +76,25 @@ it('uses current date for release date if option is empty', function () {
          ->expectsOutput($expectedOutput)
          ->assertExitCode(0);
 });
+
+it('places given release notes in correct position in given markdown changelog when no unreleased heading is available', function () {
+
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
+        '--release-date' => '2021-02-01',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased.md'))
+         ->assertExitCode(0);
+});

--- a/tests/Stubs/base-changelog-without-unreleased.md
+++ b/tests/Stubs/base-changelog-without-unreleased.md
@@ -1,8 +1,4 @@
 # Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## v0.1.0 - 2021-01-01
 

--- a/tests/Stubs/base-changelog-without-unreleased.md
+++ b/tests/Stubs/base-changelog-without-unreleased.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## v0.1.0 - 2021-01-01
+
+### Added
+- Initial Release

--- a/tests/Stubs/expected-changelog-without-unreleased.md
+++ b/tests/Stubs/expected-changelog-without-unreleased.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## v1.0.0 - 2021-02-01
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+
+- Initial Release

--- a/tests/Stubs/expected-changelog-without-unreleased.md
+++ b/tests/Stubs/expected-changelog-without-unreleased.md
@@ -1,10 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
 ## v1.0.0 - 2021-02-01
 
 ### Added

--- a/tests/Unit/FindFirstSecondLevelHeadingTest.php
+++ b/tests/Unit/FindFirstSecondLevelHeadingTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\FindFirstSecondLevelHeading;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Parser\MarkdownParser;
+
+it('finds first second level heading in markdown ast', function () {
+    $markdown = <<<MD
+    ## v1.1.0
+    ## v1.0.0
+    MD;
+
+    $env = new Environment();
+    $env->addExtension(new CommonMarkCoreExtension());
+    $parser = new MarkdownParser($env);
+
+    $ast = $parser->parse($markdown);
+
+    $result = app(FindFirstSecondLevelHeading::class)->find($ast);
+
+    $this->assertNotNull($result);
+    $this->assertInstanceOf(Heading::class, $result);
+
+    $this->assertEquals('v1.1.0', $result->firstChild()->getLiteral());
+});
+
+it('finds first second level heading in markdown ast if heading contains a link', function () {
+    $markdown = <<<MD
+    ## [v1.1.0](http://example.com)
+    ## [v1.0.0](http://example.com)
+    MD;
+
+    $env = new Environment();
+    $env->addExtension(new CommonMarkCoreExtension());
+    $parser = new MarkdownParser($env);
+
+    $ast = $parser->parse($markdown);
+
+    /** @var Heading $result */
+    $result = app(FindFirstSecondLevelHeading::class)->find($ast);
+
+    $this->assertNotNull($result);
+    $this->assertInstanceOf(Heading::class, $result);
+
+    $this->assertEquals('v1.1.0', $result->firstChild()->firstChild()->getLiteral());
+});


### PR DESCRIPTION
This PR updates the CLI to no longer fail if no `Unreleased`-heading can be found in the existing `CHANGELOG.md`. Instead, it prepends the passed release notes to the first second level heading it can find.

This way, the CLI can also support changelogs that look like this.

```md
# Changelog

## v0.1.0 - 2021-01-01

### Added
- Initial Release
```