### PR TITLE
Add Release Notes at the end if no heading was found

### DIFF
--- a/app/Actions/PasteReleaseNotesAtTheTop.php
+++ b/app/Actions/PasteReleaseNotesAtTheTop.php
@@ -33,11 +33,11 @@ class PasteReleaseNotesAtTheTop
         // Find the Heading of the previous Version
         $previousVersionHeading = $this->findFirstSecondLevelHeading->find($changelog);
 
-        if ($previousVersionHeading === null) {
-            $changelog->lastChild()?->insertAfter($parsedReleaseNotes);
-        } else {
+        if ($previousVersionHeading !== null) {
             // Insert the newest Release Notes before the previous Release Heading
-            $previousVersionHeading?->insertBefore($parsedReleaseNotes);
+            $previousVersionHeading->insertBefore($parsedReleaseNotes);
+        } else {
+            $changelog->lastChild()?->insertAfter($parsedReleaseNotes);
         }
 
         return $changelog;

--- a/app/Actions/PasteReleaseNotesAtTheTop.php
+++ b/app/Actions/PasteReleaseNotesAtTheTop.php
@@ -33,8 +33,12 @@ class PasteReleaseNotesAtTheTop
         // Find the Heading of the previous Version
         $previousVersionHeading = $this->findFirstSecondLevelHeading->find($changelog);
 
-        // Insert the newest Release Notes before the previous Release Heading
-        $previousVersionHeading?->insertBefore($parsedReleaseNotes);
+        if ($previousVersionHeading === null) {
+            $changelog->lastChild()?->insertAfter($parsedReleaseNotes);
+        } else {
+            // Insert the newest Release Notes before the previous Release Heading
+            $previousVersionHeading?->insertBefore($parsedReleaseNotes);
+        }
 
         return $changelog;
     }

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -97,3 +97,24 @@ it('places given release notes in correct position in given markdown changelog w
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased.md'))
          ->assertExitCode(0);
 });
+
+it('places given release notes in correct position in given markdown changelog when no heading is available', function () {
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-headings.md',
+        '--release-date' => '2021-02-01',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-headings.md'))
+         ->assertExitCode(0);
+});

--- a/tests/Stubs/base-changelog-without-headings.md
+++ b/tests/Stubs/base-changelog-without-headings.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).

--- a/tests/Stubs/expected-changelog-without-headings.md
+++ b/tests/Stubs/expected-changelog-without-headings.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## v1.0.0 - 2021-02-01
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D


### PR DESCRIPTION
In case the existing Changelog does not contain a second level heading, the release notes are added at the end of the document.