### PR TITLE
Append release notes at the end if no previous heading can be found

### DIFF
--- a/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
+++ b/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
@@ -56,8 +56,12 @@ class PasteReleaseNotesBelowUnreleasedHeading
         // Find the Heading of the previous Version
         $previousVersionHeading = $this->findPreviousVersionHeading->find($changelog, $previousVersion);
 
-        // Insert the newest Release Notes before the previous Release Heading
-        $previousVersionHeading?->insertBefore($parsedReleaseNotes);
+        if ($previousVersionHeading !== null) {
+            // Insert the newest Release Notes before the previous Release Heading
+            $previousVersionHeading->insertBefore($parsedReleaseNotes);
+        } else {
+            $changelog->lastChild()?->insertAfter($parsedReleaseNotes);
+        }
 
         return $changelog;
     }

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -164,7 +164,7 @@ it('places given release notes in correct position even if changelog is empty be
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-empty-with-unreleased.md'))
          ->assertExitCode(0);
-})->only();
+});
 
 it('uses compare-url-target option in unreleased heading url', function () {
     $this->artisan('update', [

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -145,6 +145,27 @@ it('places given release notes in correct position even if the release notes and
          ->assertExitCode(0);
 });
 
+it('places given release notes in correct position even if changelog is empty besides an unreleased heading', function () {
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-empty-with-unreleased.md',
+        '--release-date' => '2021-02-01',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-empty-with-unreleased.md'))
+         ->assertExitCode(0);
+})->only();
+
 it('uses compare-url-target option in unreleased heading url', function () {
     $this->artisan('update', [
         '--release-notes' => <<<MD

--- a/tests/Stubs/base-changelog-empty-with-unreleased.md
+++ b/tests/Stubs/base-changelog-empty-with-unreleased.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/org/repo/compare/v0.1.0...HEAD)

--- a/tests/Stubs/expected-changelog-empty-with-unreleased.md
+++ b/tests/Stubs/expected-changelog-empty-with-unreleased.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -20,9 +21,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removes
 
 - Remove Feature D
-
-## v0.1.0 - 2021-01-01
-
-### Added
-
-- Initial Release

--- a/tests/Stubs/expected-changelog-empty-with-unreleased.md
+++ b/tests/Stubs/expected-changelog-empty-with-unreleased.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/org/repo/compare/v1.0.0...HEAD)
+
+## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+
+- Initial Release


### PR DESCRIPTION
This PR fixes an issue that has been discovered – again – by the Laravel team in https://github.com/laravel/laravel/pull/5803.

If a changelog has an "Unreleased" heading, but no previous heading could be found, the release notes **where not** added to the changelog.

This PR fixes this. If no previous version heading could be found, the release notes "block" is added at the end of the document.