### PR TITLE
Make Release Notes Optional

### DIFF
--- a/app/Actions/AddReleaseNotesToChangelog.php
+++ b/app/Actions/AddReleaseNotesToChangelog.php
@@ -41,7 +41,7 @@ class AddReleaseNotesToChangelog
     /**
      * @throws Throwable
      */
-    public function execute(string $originalChangelog, string $releaseNotes, string $latestVersion, string $releaseDate, string $compareUrlTargetRevision): RenderedContentInterface
+    public function execute(string $originalChangelog, ?string $releaseNotes, string $latestVersion, string $releaseDate, string $compareUrlTargetRevision): RenderedContentInterface
     {
         $changelog = $this->markdownParser->parse($originalChangelog);
 

--- a/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
+++ b/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
@@ -37,7 +37,7 @@ class PasteReleaseNotesBelowUnreleasedHeading
     /**
      * @throws Throwable
      */
-    public function execute(Heading $unreleasedHeading, string $latestVersion, string $releaseDate, string $releaseNotes, Document $changelog, string $compareUrlTargetRevision): Document
+    public function execute(Heading $unreleasedHeading, string $latestVersion, string $releaseDate, ?string $releaseNotes, Document $changelog, string $compareUrlTargetRevision): Document
     {
         $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($unreleasedHeading);
         $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($unreleasedHeading);
@@ -49,18 +49,25 @@ class PasteReleaseNotesBelowUnreleasedHeading
         // Create new Heading containing the new version number
         $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $releaseDate);
 
-        // Prepend the new Release Heading to the Release Notes
-        $parsedReleaseNotes = $this->parser->parse($releaseNotes);
-        $parsedReleaseNotes->prependChild($newReleaseHeading);
-
-        // Find the Heading of the previous Version
-        $previousVersionHeading = $this->findPreviousVersionHeading->find($changelog, $previousVersion);
-
-        if ($previousVersionHeading !== null) {
-            // Insert the newest Release Notes before the previous Release Heading
-            $previousVersionHeading->insertBefore($parsedReleaseNotes);
+        if (is_null($releaseNotes)) {
+            // If no Release Notes have been passed, add the new Release Heading below the updated Unreleased Heading.
+            // We assume that the user already added their release notes under the Unreleased Heading.
+            $unreleasedHeading->insertAfter($newReleaseHeading);
         } else {
-            $changelog->lastChild()?->insertAfter($parsedReleaseNotes);
+
+            // Prepend the new Release Heading to the Release Notes
+            $parsedReleaseNotes = $this->parser->parse($releaseNotes);
+            $parsedReleaseNotes->prependChild($newReleaseHeading);
+
+            // Find the Heading of the previous Version
+            $previousVersionHeading = $this->findPreviousVersionHeading->find($changelog, $previousVersion);
+
+            if ($previousVersionHeading !== null) {
+                // Insert the newest Release Notes before the previous Release Heading
+                $previousVersionHeading->insertBefore($parsedReleaseNotes);
+            } else {
+                $changelog->lastChild()?->insertAfter($parsedReleaseNotes);
+            }
         }
 
         return $changelog;

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -60,7 +60,6 @@ class UpdateCommand extends Command
 
     private function validateOptions(): void
     {
-        Assert::stringNotEmpty($this->option('release-notes'), 'No release-notes option provided. Abort.');
         Assert::stringNotEmpty($this->option('latest-version'), 'No latest-version option provided. Abort.');
     }
 

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -188,3 +188,14 @@ it('shows warning if version already exists in the changelog', function () {
          ->expectsOutput('CHANGELOG was not updated as release notes for v0.1.0 already exist.')
          ->assertExitCode(0);
 });
+
+it('uses existing content between unreleased and previous version heading as release notes', function () {
+    $this->artisan('update', [
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-with-unreleased-notes.md',
+        '--release-date' => '2021-02-01',
+        '--compare-url-target-revision' => '1.x',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
+         ->assertExitCode(0);
+});

--- a/tests/Stubs/base-changelog-with-unreleased-notes.md
+++ b/tests/Stubs/base-changelog-with-unreleased-notes.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/org/repo/compare/v0.1.0...HEAD)
+
+### Added
+- New Feature A
+- New Feature B
+
+### Changed
+- Update Feature C
+
+### Removes
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+- Initial Release

--- a/tests/Stubs/expected-changelog-with-unreleased-notes.md
+++ b/tests/Stubs/expected-changelog-with-unreleased-notes.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/org/repo/compare/v1.0.0...HEAD)
+
+## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
+
+### Added
+- New Feature A
+- New Feature B
+
+### Changed
+- Update Feature C
+
+### Removes
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+- Initial Release

--- a/tests/Stubs/expected-changelog-with-unreleased-notes.md
+++ b/tests/Stubs/expected-changelog-with-unreleased-notes.md
@@ -1,24 +1,29 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/org/repo/compare/v1.0.0...HEAD)
+## [Unreleased](https://github.com/org/repo/compare/v1.0.0...1.x)
 
 ## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
 
 ### Added
+
 - New Feature A
 - New Feature B
 
 ### Changed
+
 - Update Feature C
 
 ### Removes
+
 - Remove Feature D
 
 ## v0.1.0 - 2021-01-01
 
 ### Added
+
 - Initial Release


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/stefanzweifel/changelog-updater-action/issues/12. It makes the `--release-notes` option optional. If no release notes have been given, a new release heading is placed directly after the Unreleased heading.

## Releated Issues
- https://github.com/stefanzweifel/changelog-updater-action/issues/12


## TODOs

- [ ] Update `PasteReleaseNotesAtTheTop`