### PR TITLE
Output GitHub Actions Output Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ Optional (Defaults to `HEAD`). If the changelog has a "Unreleased" heading, the 
 ### `--write`
 Optional. Write the changes to `CHANGELOG.md` or to the value of `--path-to-changelog`.
 
+### `--github-action-output`
+Optional. Will output values for `UNRELEASED_COMPARE_URL` and `RELEASE_COMPARE_URL` that can be picked up by GitHub Actions and further used in ones Workflow. 
+
 ## Expected Changelog Formats
 
 The CLI does its best to place the given release notes in the right place. 
-
 The CLI looks for the first second level heading in your current `CHANGELOG.md` file. It assumes that this heading represents the previous version. Here is an example of a `CHANGELOG.md` that the CLI can understand.
 
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Optional (Defaults to `HEAD`). If the changelog has a "Unreleased" heading, the 
 ### `--write`
 Optional. Write the changes to `CHANGELOG.md` or to the value of `--path-to-changelog`.
 
-### `--github-action-output`
+### `--github-actions-output`
 Optional. Will output values for `UNRELEASED_COMPARE_URL` and `RELEASE_COMPARE_URL` that can be picked up by GitHub Actions and further used in ones Workflow. 
 
 ## Expected Changelog Formats

--- a/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
+++ b/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
@@ -8,6 +8,7 @@ use App\CreateNewReleaseHeading;
 use App\GenerateCompareUrl;
 use App\MarkdownParser;
 use App\Queries\FindSecondLevelHeadingWithText;
+use App\Support\GitHubActionsOutput;
 use Illuminate\Support\Str;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
@@ -21,17 +22,20 @@ class PasteReleaseNotesBelowUnreleasedHeading
     private GenerateCompareUrl $generateCompareUrl;
     private FindSecondLevelHeadingWithText $findPreviousVersionHeading;
     private CreateNewReleaseHeading $createNewReleaseHeading;
+    private GitHubActionsOutput $gitHubActionsOutput;
 
     public function __construct(
         MarkdownParser                 $markdownParser,
         GenerateCompareUrl             $generateCompareUrl,
         FindSecondLevelHeadingWithText $findPreviousVersionHeading,
-        CreateNewReleaseHeading        $createNewReleaseHeading
+        CreateNewReleaseHeading        $createNewReleaseHeading,
+        GitHubActionsOutput $gitHubActionsOutput
     ) {
         $this->parser = $markdownParser;
         $this->generateCompareUrl = $generateCompareUrl;
         $this->findPreviousVersionHeading = $findPreviousVersionHeading;
         $this->createNewReleaseHeading = $createNewReleaseHeading;
+        $this->gitHubActionsOutput = $gitHubActionsOutput;
     }
 
     /**
@@ -45,6 +49,7 @@ class PasteReleaseNotesBelowUnreleasedHeading
 
         $link = $this->getLinkNodeFromHeading($unreleasedHeading);
         $link->setUrl($updatedUrl);
+        $this->gitHubActionsOutput->add('UNRELEASED_COMPARE_URL', $updatedUrl);
 
         // Create new Heading containing the new version number
         $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $releaseDate);

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -56,6 +56,7 @@ class UpdateCommand extends Command
             );
             $this->info($updatedChangelog->getContent());
             $this->writeChangelogToFile($pathToChangelog, $updatedChangelog);
+
             return self::SUCCESS;
         } catch (ReleaseAlreadyExistsInChangelogException $exception) {
             $this->warn($exception->getMessage());

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -21,7 +21,7 @@ class UpdateCommand extends Command
         {--release-date= : Date when latest version has been released. Defaults to today.}
         {--path-to-changelog=CHANGELOG.md : Path to changelog markdown file to be updated.}
         {--compare-url-target-revision=HEAD : Target revision used in the compare URL of possible "Unreleased" heading.}
-        {--github-action-output=false: Display GitHub Actions related output}
+        {--github-actions-output=false: Display GitHub Actions related output}
         {-w\--write : Write changes to file}
     ';
 
@@ -67,7 +67,7 @@ class UpdateCommand extends Command
 
             return self::FAILURE;
         } finally {
-            if ($this->option('github-action-output')) {
+            if ($this->option('github-actions-output')) {
                 $gitHubActionsOutput->render($this->getOutput());
             }
         }

--- a/app/CreateNewReleaseHeading.php
+++ b/app/CreateNewReleaseHeading.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\Support\GitHubActionsOutput;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Node\Inline\Text;
@@ -11,15 +12,19 @@ use League\CommonMark\Node\Inline\Text;
 class CreateNewReleaseHeading
 {
     private GenerateCompareUrl $generateCompareUrl;
+    private GitHubActionsOutput $gitHubActionsOutput;
 
-    public function __construct(GenerateCompareUrl $generateCompareUrl)
+    public function __construct(GenerateCompareUrl $generateCompareUrl, GitHubActionsOutput $gitHubActionsOutput)
     {
         $this->generateCompareUrl = $generateCompareUrl;
+        $this->gitHubActionsOutput = $gitHubActionsOutput;
     }
 
     public function create(string $repositoryUrl, string $previousVersion, string $latestVersion, string $releaseDate): Heading
     {
         $url = $this->generateCompareUrl->generate($repositoryUrl, $previousVersion, $latestVersion);
+
+        $this->gitHubActionsOutput->add('RELEASE_COMPARE_URL', $url);
 
         return tap(new Heading(2), function (Heading $heading) use ($url, $latestVersion, $releaseDate) {
             $heading->appendChild($this->createLinkNode($latestVersion, $url));

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,7 +16,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app->singleton(GitHubActionsOutput::class, fn() => new GitHubActionsOutput());
+        $this->app->singleton(GitHubActionsOutput::class, fn () => new GitHubActionsOutput());
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,9 +16,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app->singleton(GitHubActionsOutput::class, function ($app) {
-            return new GitHubActionsOutput();
-        });
+        $this->app->singleton(GitHubActionsOutput::class, fn() => new GitHubActionsOutput());
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Support\GitHubActionsOutput;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -15,7 +16,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->app->singleton(GitHubActionsOutput::class, function ($app) {
+            return new GitHubActionsOutput();
+        });
     }
 
     /**

--- a/app/Support/GitHubActionsOutput.php
+++ b/app/Support/GitHubActionsOutput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Support;
 
 use Illuminate\Console\OutputStyle;

--- a/app/Support/GitHubActionsOutput.php
+++ b/app/Support/GitHubActionsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Support\MessageBag;
+
+class GitHubActionsOutput extends MessageBag
+{
+    public function render(OutputStyle $output): void
+    {
+        foreach ($this->messages() as $key => $message) {
+            $output->text(sprintf("::set-output name=%s::%s", $key, head($message)));
+        }
+    }
+}

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -39,7 +39,7 @@ it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
         '--release-date' => '2021-02-01',
-        '--github-action-output' => true,
+        '--github-actions-output' => true,
     ])
          ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
          ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -23,6 +23,29 @@ it('places given release notes in correct position in given markdown changelog',
          ->assertExitCode(0);
 });
 
+it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in CI environment', function () {
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
+        '--release-date' => '2021-02-01',
+        '--github-action-output' => true,
+    ])
+         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
+         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
+         ->assertExitCode(0);
+});
+
 it('throws error if latest-version is missing', function () {
     $this->artisan('update', [
         '--release-notes' => '::release-notes::',


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/stefanzweifel/changelog-updater-action/issues/14. If enabled through the `--github-actions-output=true` option, the CLI will create GitHub Actions output variables.

The values are:

- `RELEASE_COMPARE_URL`: The compare URL between the previous and latest release (eg. `https://github.com/org/repo/compare/v0.1.0...v1.0.0`)
- `UNRELEASED_COMPARE_URL`: The compare URL between the latest release and the target revision (eg. `https://github.com/org/repo/compare/v1.0.0...HEAD`)

Have not tested yet, if this actually works in GitHub Actions. 

---

I think the use of `Illuminate\Support\MessageBag` in the `GitHubActionsOutput`-singleton is pretty smart, as we can reuse the powerful `MessageBag`-component from Laravel. 🏄 

## Related Issues
- https://github.com/stefanzweifel/changelog-updater-action/issues/14