### PR TITLE
Fix detection of empty release notes

### DIFF
--- a/app/Actions/PasteReleaseNotesAtTheTop.php
+++ b/app/Actions/PasteReleaseNotesAtTheTop.php
@@ -28,7 +28,7 @@ class PasteReleaseNotesAtTheTop
      */
     public function execute(string $latestVersion, ?string $releaseNotes, string $releaseDate, Document $changelog): Document
     {
-        throw_if(is_null($releaseNotes), ReleaseNotesNotProvidedException::class);
+        throw_if(empty($releaseNotes), ReleaseNotesNotProvidedException::class);
 
         // Create new Heading containing the new version and date
         $newReleaseHeading = $this->createNewReleaseHeading($latestVersion, $releaseDate);

--- a/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
+++ b/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
@@ -54,7 +54,7 @@ class PasteReleaseNotesBelowUnreleasedHeading
         // Create new Heading containing the new version number
         $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $releaseDate);
 
-        if (is_null($releaseNotes)) {
+        if (empty($releaseNotes)) {
             // If no Release Notes have been passed, add the new Release Heading below the updated Unreleased Heading.
             // We assume that the user already added their release notes under the Unreleased Heading.
             $unreleasedHeading->insertAfter($newReleaseHeading);

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -207,7 +207,19 @@ it('shows warning if version already exists in the changelog', function () {
          ->assertExitCode(0);
 });
 
-it('uses existing content between unreleased and previous version heading as release notes', function () {
+it('uses existing content between unreleased and previous version heading as release notes if release notes are empty', function () {
+    $this->artisan('update', [
+        '--release-notes' => '',
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-with-unreleased-notes.md',
+        '--release-date' => '2021-02-01',
+        '--compare-url-target-revision' => '1.x',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
+         ->assertExitCode(0);
+});
+
+it('uses existing content between unreleased and previous version heading as release notes if release notes option is not provided', function () {
     $this->artisan('update', [
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-with-unreleased-notes.md',

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -20,7 +20,7 @@ it('places given release notes in correct position in given markdown changelog',
         '--release-date' => '2021-02-01',
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog.md'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in CI environment', function () {
@@ -43,14 +43,14 @@ it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in
     ])
          ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
          ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('throws error if latest-version is missing', function () {
     $this->artisan('update', [
         '--release-notes' => '::release-notes::',
         ])
-       ->assertExitCode(1);
+       ->assertFailed();
 })->throws(InvalidArgumentException::class, 'No latest-version option provided. Abort.');
 
 it('uses current date for release date if no option is provieded', function () {
@@ -73,7 +73,7 @@ it('uses current date for release date if no option is provieded', function () {
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
     ])
          ->expectsOutput($expectedOutput)
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('uses current date for release date if option is empty', function () {
@@ -97,7 +97,7 @@ it('uses current date for release date if option is empty', function () {
         '--release-date' => '',
     ])
          ->expectsOutput($expectedOutput)
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('places given release notes in correct position in given markdown changelog when no unreleased heading is available', function () {
@@ -118,7 +118,7 @@ it('places given release notes in correct position in given markdown changelog w
         '--release-date' => '2021-02-01',
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased.md'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('places given release notes in correct position in given markdown changelog when no heading is available', function () {
@@ -139,7 +139,7 @@ it('places given release notes in correct position in given markdown changelog w
         '--release-date' => '2021-02-01',
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-headings.md'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('places given release notes in correct position even if changelog is empty besides an unreleased heading', function () {
@@ -160,7 +160,7 @@ it('places given release notes in correct position even if changelog is empty be
         '--release-date' => '2021-02-01',
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-empty-with-unreleased.md'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('uses compare-url-target option in unreleased heading url', function () {
@@ -182,7 +182,7 @@ it('uses compare-url-target option in unreleased heading url', function () {
         '--compare-url-target-revision' => '1.x',
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-custom-compare-url-target.md'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('shows warning if version already exists in the changelog', function () {
@@ -204,7 +204,7 @@ it('shows warning if version already exists in the changelog', function () {
         '--compare-url-target-revision' => '1.x',
     ])
          ->expectsOutput('CHANGELOG was not updated as release notes for v0.1.0 already exist.')
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('uses existing content between unreleased and previous version heading as release notes if release notes are empty', function () {
@@ -216,7 +216,7 @@ it('uses existing content between unreleased and previous version heading as rel
         '--compare-url-target-revision' => '1.x',
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('uses existing content between unreleased and previous version heading as release notes if release notes option is not provided', function () {
@@ -227,7 +227,7 @@ it('uses existing content between unreleased and previous version heading as rel
         '--compare-url-target-revision' => '1.x',
     ])
          ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
-         ->assertExitCode(0);
+         ->assertSuccessful();
 });
 
 it('nothing happens if no release notes have been given and no unreleased heading can be found', function () {


### PR DESCRIPTION
Instead of using `is_null()` to detect empty release notes, we now use `empty()`. The Action itself always passed the option but only changes the value from a string to an empty string `""`.

See https://github.com/stefanzweifel/changelog-updater-action/issues/12#issuecomment-1073115279.