### PR TITLE
Add RELEASE_HEADING_FRAGMENT output

### DIFF
--- a/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
+++ b/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
@@ -29,7 +29,7 @@ class ExtractNewReleaseHeadingFragmentAction
     {
         $releaseHeading = clone $releaseHeading;
 
-        $renderedHtml = $this->attachHeadingPermalinkAndParseAsHtml($releaseHeading);
+        $renderedHtml = $this->attachPermalinkAndRenderAsHtml($releaseHeading);
         $linkFragment = $this->extractLinkFragmentFromRenderedHtml($renderedHtml);
 
         return tap($linkFragment, function (string $linkFragment) {
@@ -37,11 +37,11 @@ class ExtractNewReleaseHeadingFragmentAction
         });
     }
 
-    protected function attachHeadingPermalinkAndParseAsHtml(Node $releaseHeading): string
+    protected function attachPermalinkAndRenderAsHtml(Node $releaseHeading): string
     {
         $environment = $this->prepareCommonmarkEnvironment();
 
-        $document = $this->attachHeadingPermalink($releaseHeading, $environment);
+        $document = $this->attachPermalinkToHeading($releaseHeading, $environment);
 
         $renderer = new HtmlRenderer($environment);
 
@@ -71,7 +71,7 @@ class ExtractNewReleaseHeadingFragmentAction
         return $environment;
     }
 
-    protected function attachHeadingPermalink(Node $releaseHeading, Environment $environment): Document
+    protected function attachPermalinkToHeading(Node $releaseHeading, Environment $environment): Document
     {
         $document = new Document();
         $document->appendChild($releaseHeading);

--- a/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
+++ b/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
@@ -85,7 +85,7 @@ class ExtractNewReleaseHeadingFragmentAction
         return $document;
     }
 
-    protected function extractLinkFragmentFromRenderedHtml(string $result): string
+    protected function extractLinkFragmentFromRenderedHtml(string $result): ?string
     {
         $domDocument = new DOMDocument();
         $domDocument->loadHTML($result);

--- a/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
+++ b/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
@@ -80,7 +80,6 @@ class ExtractNewReleaseHeadingFragmentAction
 
         $processor = (new HeadingPermalinkProcessor());
         $processor->setEnvironment($environment);
-        // Tests fail when running this line :/
         $processor->__invoke($documentParsedEvent);
 
         return $document;

--- a/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
+++ b/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions;
 
 use App\Support\GitHubActionsOutput;
 use DOMDocument;
-use League\CommonMark\Event\DocumentParsedEvent;
-use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkProcessor;
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkProcessor;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkRenderer;
 use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Node;
@@ -25,6 +27,8 @@ class ExtractNewReleaseHeadingFragmentAction
 
     public function execute(Node $releaseHeading): string
     {
+        $releaseHeading = clone $releaseHeading;
+
         $renderedHtml = $this->attachHeadingPermalinkAndParseAsHtml($releaseHeading);
         $linkFragment = $this->extractLinkFragmentFromRenderedHtml($renderedHtml);
 
@@ -40,6 +44,7 @@ class ExtractNewReleaseHeadingFragmentAction
         $document = $this->attachHeadingPermalink($releaseHeading, $environment);
 
         $renderer = new HtmlRenderer($environment);
+
         return $renderer->renderDocument($document)->getContent();
     }
 
@@ -62,6 +67,7 @@ class ExtractNewReleaseHeadingFragmentAction
         $environment = new Environment($config);
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new HeadingPermalinkExtension());
+
         return $environment;
     }
 
@@ -76,6 +82,7 @@ class ExtractNewReleaseHeadingFragmentAction
         $processor->setEnvironment($environment);
         // Tests fail when running this line :/
         $processor->__invoke($documentParsedEvent);
+
         return $document;
     }
 

--- a/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
+++ b/app/Actions/ExtractNewReleaseHeadingFragmentAction.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Actions;
+
+use App\Support\GitHubActionsOutput;
+use DOMDocument;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkProcessor;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkRenderer;
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\HtmlRenderer;
+
+class ExtractNewReleaseHeadingFragmentAction
+{
+    private GitHubActionsOutput $gitHubActionsOutput;
+
+    public function __construct(GitHubActionsOutput $gitHubActionsOutput)
+    {
+        $this->gitHubActionsOutput = $gitHubActionsOutput;
+    }
+
+    public function execute(Node $releaseHeading): string
+    {
+        $renderedHtml = $this->attachHeadingPermalinkAndParseAsHtml($releaseHeading);
+        $linkFragment = $this->extractLinkFragmentFromRenderedHtml($renderedHtml);
+
+        return tap($linkFragment, function (string $linkFragment) {
+            $this->gitHubActionsOutput->add('RELEASE_URL_FRAGMENT', $linkFragment);
+        });
+    }
+
+    protected function attachHeadingPermalinkAndParseAsHtml(Node $releaseHeading): string
+    {
+        $environment = $this->prepareCommonmarkEnvironment();
+
+        $document = $this->attachHeadingPermalink($releaseHeading, $environment);
+
+        $renderer = new HtmlRenderer($environment);
+        return $renderer->renderDocument($document)->getContent();
+    }
+
+    protected function prepareCommonmarkEnvironment(): Environment
+    {
+        $config = [
+            'heading_permalink' => [
+                'html_class' => '',
+                'id_prefix' => '',
+                'fragment_prefix' => '',
+                'insert' => 'before',
+                'min_heading_level' => 1,
+                'max_heading_level' => 6,
+                'title' => '',
+                'symbol' => HeadingPermalinkRenderer::DEFAULT_SYMBOL,
+                'aria_hidden' => false,
+            ],
+        ];
+
+        $environment = new Environment($config);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
+        return $environment;
+    }
+
+    protected function attachHeadingPermalink(Node $releaseHeading, Environment $environment): Document
+    {
+        $document = new Document();
+        $document->appendChild($releaseHeading);
+
+        $documentParsedEvent = new DocumentParsedEvent($document);
+
+        $processor = (new HeadingPermalinkProcessor());
+        $processor->setEnvironment($environment);
+        // Tests fail when running this line :/
+        $processor->__invoke($documentParsedEvent);
+        return $document;
+    }
+
+    protected function extractLinkFragmentFromRenderedHtml(string $result): string
+    {
+        $domDocument = new DOMDocument();
+        $domDocument->loadHTML($result);
+
+        return $domDocument
+            ->getElementsByTagName('a')
+            ->item(0)
+            ->attributes
+            ->getNamedItem('href')
+            ->value;
+    }
+}

--- a/app/Actions/ExtractPermalinkFragmentFromHeading.php
+++ b/app/Actions/ExtractPermalinkFragmentFromHeading.php
@@ -16,7 +16,7 @@ use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\HtmlRenderer;
 
-class ExtractNewReleaseHeadingFragmentAction
+class ExtractPermalinkFragmentFromHeading
 {
     private GitHubActionsOutput $gitHubActionsOutput;
 

--- a/app/Actions/ExtractPermalinkFragmentFromHeading.php
+++ b/app/Actions/ExtractPermalinkFragmentFromHeading.php
@@ -9,11 +9,11 @@ use DOMDocument;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkProcessor;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkRenderer;
 use League\CommonMark\Node\Block\Document;
-use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\HtmlRenderer;
 
 class ExtractPermalinkFragmentFromHeading
@@ -25,7 +25,7 @@ class ExtractPermalinkFragmentFromHeading
         $this->gitHubActionsOutput = $gitHubActionsOutput;
     }
 
-    public function execute(Node $releaseHeading): string
+    public function execute(Heading $releaseHeading): string
     {
         $releaseHeading = clone $releaseHeading;
 
@@ -37,7 +37,7 @@ class ExtractPermalinkFragmentFromHeading
         });
     }
 
-    protected function attachPermalinkAndRenderAsHtml(Node $releaseHeading): string
+    protected function attachPermalinkAndRenderAsHtml(Heading $releaseHeading): string
     {
         $environment = $this->prepareCommonmarkEnvironment();
 
@@ -74,11 +74,11 @@ class ExtractPermalinkFragmentFromHeading
     /**
      * Attach Heading Permalink to given ReleaseHeading using
      * the Commonmark Heading Permalink Extension.
-     * @param Node $releaseHeading
+     * @param Heading $releaseHeading
      * @param Environment $environment
      * @return Document
      */
-    protected function attachPermalinkToHeading(Node $releaseHeading, Environment $environment): Document
+    protected function attachPermalinkToHeading(Heading $releaseHeading, Environment $environment): Document
     {
         $document = new Document();
         $document->appendChild($releaseHeading);

--- a/app/Actions/ExtractPermalinkFragmentFromHeading.php
+++ b/app/Actions/ExtractPermalinkFragmentFromHeading.php
@@ -71,6 +71,13 @@ class ExtractPermalinkFragmentFromHeading
         return $environment;
     }
 
+    /**
+     * Attach Heading Permalink to given ReleaseHeading using
+     * the Commonmark Heading Permalink Extension.
+     * @param Node $releaseHeading
+     * @param Environment $environment
+     * @return Document
+     */
     protected function attachPermalinkToHeading(Node $releaseHeading, Environment $environment): Document
     {
         $document = new Document();
@@ -85,10 +92,16 @@ class ExtractPermalinkFragmentFromHeading
         return $document;
     }
 
-    protected function extractLinkFragmentFromRenderedHtml(string $result): ?string
+    /**
+     * Parse the rendered HTML as a DOM Document and extract the
+     * href attribute from the generated a-tag.
+     * @param string $html
+     * @return string|null
+     */
+    protected function extractLinkFragmentFromRenderedHtml(string $html): ?string
     {
         $domDocument = new DOMDocument();
-        $domDocument->loadHTML($result);
+        $domDocument->loadHTML($html);
 
         return $domDocument
             ->getElementsByTagName('a')

--- a/app/Actions/PasteReleaseNotesAtTheTop.php
+++ b/app/Actions/PasteReleaseNotesAtTheTop.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\CreateNewReleaseHeading;
 use App\Exceptions\ReleaseNotesNotProvidedException;
 use App\MarkdownParser;
 use App\Queries\FindFirstSecondLevelHeading;
-use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Node\Block\Document;
-use League\CommonMark\Node\Inline\Text;
 use Throwable;
 
 class PasteReleaseNotesAtTheTop
 {
     private FindFirstSecondLevelHeading $findFirstSecondLevelHeading;
     private MarkdownParser $parser;
+    private CreateNewReleaseHeading $createNewReleaseHeading;
 
-    public function __construct(FindFirstSecondLevelHeading $findFirstSecondLevelHeading, MarkdownParser $markdownParser)
+    public function __construct(FindFirstSecondLevelHeading $findFirstSecondLevelHeading, MarkdownParser $markdownParser, CreateNewReleaseHeading $createNewReleaseHeading)
     {
         $this->findFirstSecondLevelHeading = $findFirstSecondLevelHeading;
         $this->parser = $markdownParser;
+        $this->createNewReleaseHeading = $createNewReleaseHeading;
     }
 
     /**
@@ -30,8 +31,7 @@ class PasteReleaseNotesAtTheTop
     {
         throw_if(empty($releaseNotes), ReleaseNotesNotProvidedException::class);
 
-        // Create new Heading containing the new version and date
-        $newReleaseHeading = $this->createNewReleaseHeading($latestVersion, $releaseDate);
+        $newReleaseHeading = $this->createNewReleaseHeading->create($latestVersion, $releaseDate);
 
         // Prepend the new Release Heading to the Release Notes
         $parsedReleaseNotes = $this->parser->parse($releaseNotes);
@@ -48,13 +48,5 @@ class PasteReleaseNotesAtTheTop
         }
 
         return $changelog;
-    }
-
-    protected function createNewReleaseHeading(string $latestVersion, string $releaseDate): Heading
-    {
-        return tap(new Heading(2), function (Heading $heading) use ($latestVersion, $releaseDate) {
-            $heading->appendChild(new Text($latestVersion));
-            $heading->appendChild(new Text(" - {$releaseDate}"));
-        });
     }
 }

--- a/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
+++ b/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
-use App\CreateNewReleaseHeading;
+use App\CreateNewReleaseHeadingWithCompareUrl;
 use App\GenerateCompareUrl;
 use App\MarkdownParser;
 use App\Queries\FindSecondLevelHeadingWithText;
@@ -21,15 +21,15 @@ class PasteReleaseNotesBelowUnreleasedHeading
     private MarkdownParser $parser;
     private GenerateCompareUrl $generateCompareUrl;
     private FindSecondLevelHeadingWithText $findPreviousVersionHeading;
-    private CreateNewReleaseHeading $createNewReleaseHeading;
+    private CreateNewReleaseHeadingWithCompareUrl $createNewReleaseHeading;
     private GitHubActionsOutput $gitHubActionsOutput;
 
     public function __construct(
-        MarkdownParser                 $markdownParser,
-        GenerateCompareUrl             $generateCompareUrl,
-        FindSecondLevelHeadingWithText $findPreviousVersionHeading,
-        CreateNewReleaseHeading        $createNewReleaseHeading,
-        GitHubActionsOutput $gitHubActionsOutput
+        MarkdownParser                        $markdownParser,
+        GenerateCompareUrl                    $generateCompareUrl,
+        FindSecondLevelHeadingWithText        $findPreviousVersionHeading,
+        CreateNewReleaseHeadingWithCompareUrl $createNewReleaseHeading,
+        GitHubActionsOutput                   $gitHubActionsOutput
     ) {
         $this->parser = $markdownParser;
         $this->generateCompareUrl = $generateCompareUrl;

--- a/app/CreateNewReleaseHeading.php
+++ b/app/CreateNewReleaseHeading.php
@@ -1,17 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
+use App\Actions\ExtractNewReleaseHeadingFragmentAction;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Node\Inline\Text;
 
 class CreateNewReleaseHeading
 {
+    private ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction;
+
+    public function __construct(ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction)
+    {
+        $this->extractNewReleaseHeadingFragmentAction = $extractNewReleaseHeadingFragmentAction;
+    }
+
     public function create(string $latestVersion, string $releaseDate): Heading
     {
         return tap(new Heading(2), function (Heading $heading) use ($latestVersion, $releaseDate) {
             $heading->appendChild(new Text($latestVersion));
             $heading->appendChild(new Text(" - {$releaseDate}"));
+
+            $this->extractNewReleaseHeadingFragmentAction->execute($heading);
         });
     }
 }

--- a/app/CreateNewReleaseHeading.php
+++ b/app/CreateNewReleaseHeading.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Node\Inline\Text;
+
+class CreateNewReleaseHeading
+{
+    public function create(string $latestVersion, string $releaseDate): Heading
+    {
+        return tap(new Heading(2), function (Heading $heading) use ($latestVersion, $releaseDate) {
+            $heading->appendChild(new Text($latestVersion));
+            $heading->appendChild(new Text(" - {$releaseDate}"));
+        });
+    }
+}

--- a/app/CreateNewReleaseHeading.php
+++ b/app/CreateNewReleaseHeading.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace App;
 
-use App\Actions\ExtractNewReleaseHeadingFragmentAction;
+use App\Actions\ExtractPermalinkFragmentFromHeading;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Node\Inline\Text;
 
 class CreateNewReleaseHeading
 {
-    private ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction;
+    private ExtractPermalinkFragmentFromHeading $extractPermalinkFragmentFromHeading;
 
-    public function __construct(ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction)
+    public function __construct(ExtractPermalinkFragmentFromHeading $extractPermalinkFragmentFromHeading)
     {
-        $this->extractNewReleaseHeadingFragmentAction = $extractNewReleaseHeadingFragmentAction;
+        $this->extractPermalinkFragmentFromHeading = $extractPermalinkFragmentFromHeading;
     }
 
     public function create(string $latestVersion, string $releaseDate): Heading
@@ -23,7 +23,7 @@ class CreateNewReleaseHeading
             $heading->appendChild(new Text($latestVersion));
             $heading->appendChild(new Text(" - {$releaseDate}"));
 
-            $this->extractNewReleaseHeadingFragmentAction->execute($heading);
+            $this->extractPermalinkFragmentFromHeading->execute($heading);
         });
     }
 }

--- a/app/CreateNewReleaseHeadingWithCompareUrl.php
+++ b/app/CreateNewReleaseHeadingWithCompareUrl.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App;
 
-use App\Actions\ExtractNewReleaseHeadingFragmentAction;
+use App\Actions\ExtractPermalinkFragmentFromHeading;
 use App\Support\GitHubActionsOutput;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
@@ -14,13 +14,13 @@ class CreateNewReleaseHeadingWithCompareUrl
 {
     private GenerateCompareUrl $generateCompareUrl;
     private GitHubActionsOutput $gitHubActionsOutput;
-    private ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction;
+    private ExtractPermalinkFragmentFromHeading $extractPermalinkFragmentFromHeading;
 
-    public function __construct(GenerateCompareUrl $generateCompareUrl, GitHubActionsOutput $gitHubActionsOutput, ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction)
+    public function __construct(GenerateCompareUrl $generateCompareUrl, GitHubActionsOutput $gitHubActionsOutput, ExtractPermalinkFragmentFromHeading $extractPermalinkFragmentFromHeading)
     {
         $this->generateCompareUrl = $generateCompareUrl;
         $this->gitHubActionsOutput = $gitHubActionsOutput;
-        $this->extractNewReleaseHeadingFragmentAction = $extractNewReleaseHeadingFragmentAction;
+        $this->extractPermalinkFragmentFromHeading = $extractPermalinkFragmentFromHeading;
     }
 
     public function create(string $repositoryUrl, string $previousVersion, string $latestVersion, string $releaseDate): Heading
@@ -33,7 +33,7 @@ class CreateNewReleaseHeadingWithCompareUrl
             $heading->appendChild($this->createLinkNode($latestVersion, $url));
             $heading->appendChild($this->createDateNode($releaseDate));
 
-            $this->extractNewReleaseHeadingFragmentAction->execute($heading);
+            $this->extractPermalinkFragmentFromHeading->execute($heading);
         });
     }
 

--- a/app/CreateNewReleaseHeadingWithCompareUrl.php
+++ b/app/CreateNewReleaseHeadingWithCompareUrl.php
@@ -9,7 +9,7 @@ use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Node\Inline\Text;
 
-class CreateNewReleaseHeading
+class CreateNewReleaseHeadingWithCompareUrl
 {
     private GenerateCompareUrl $generateCompareUrl;
     private GitHubActionsOutput $gitHubActionsOutput;

--- a/app/CreateNewReleaseHeadingWithCompareUrl.php
+++ b/app/CreateNewReleaseHeadingWithCompareUrl.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\Actions\ExtractNewReleaseHeadingFragmentAction;
 use App\Support\GitHubActionsOutput;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
@@ -13,11 +14,13 @@ class CreateNewReleaseHeadingWithCompareUrl
 {
     private GenerateCompareUrl $generateCompareUrl;
     private GitHubActionsOutput $gitHubActionsOutput;
+    private ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction;
 
-    public function __construct(GenerateCompareUrl $generateCompareUrl, GitHubActionsOutput $gitHubActionsOutput)
+    public function __construct(GenerateCompareUrl $generateCompareUrl, GitHubActionsOutput $gitHubActionsOutput, ExtractNewReleaseHeadingFragmentAction $extractNewReleaseHeadingFragmentAction)
     {
         $this->generateCompareUrl = $generateCompareUrl;
         $this->gitHubActionsOutput = $gitHubActionsOutput;
+        $this->extractNewReleaseHeadingFragmentAction = $extractNewReleaseHeadingFragmentAction;
     }
 
     public function create(string $repositoryUrl, string $previousVersion, string $latestVersion, string $releaseDate): Heading
@@ -29,6 +32,8 @@ class CreateNewReleaseHeadingWithCompareUrl
         return tap(new Heading(2), function (Heading $heading) use ($url, $latestVersion, $releaseDate) {
             $heading->appendChild($this->createLinkNode($latestVersion, $url));
             $heading->appendChild($this->createDateNode($releaseDate));
+
+            $this->extractNewReleaseHeadingFragmentAction->execute($heading);
         });
     }
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
+        "ext-dom": "*",
         "league/commonmark": "^2.0",
         "webmozart/assert": "^1.10",
         "wnx/commonmark-markdown-renderer": "^1.0"

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -42,6 +42,7 @@ it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in
         '--github-actions-output' => true,
     ])
          ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
+         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_URL_FRAGMENT', '#v100---2021-02-01'))
          ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
          ->assertSuccessful();
 });

--- a/tests/Unit/CreateNewReleaseHeadingTest.php
+++ b/tests/Unit/CreateNewReleaseHeadingTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\CreateNewReleaseHeading;
+use App\CreateNewReleaseHeadingWithCompareUrl;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
@@ -22,7 +22,7 @@ test('creates new release heading ast', function () {
     $markdownRenderer = new MarkdownRenderer($environment);
 
     /** @var Document $result */
-    $result = app(CreateNewReleaseHeading::class)->create(
+    $result = app(CreateNewReleaseHeadingWithCompareUrl::class)->create(
         $repositoryUrl,
         $previousVersion,
         $latestVersion,


### PR DESCRIPTION
This PR adds a new `ExtractPermalinkFragmentFromHeading`-action. It generates/extracts the URL fragment of the given heading, so that the consumer of the CLI/Action can generate an URL to point directly to the created release.

The Action:

- attaches a [heading permalink](https://commonmark.thephpleague.com/2.2/extensions/heading-permalinks/) to the given given heading
- renders the heading to HTML
- extracts the `href`-value 
- outputs the value for GitHub Actions as `RELEASE_URL_FRAGMENT`

fixes https://github.com/stefanzweifel/changelog-updater-action/issues/13.