### PR TITLE
Fix: Abort and Show Error Message when Release Notes could not be placed

### DIFF
--- a/app/Actions/PasteReleaseNotesAtTheTop.php
+++ b/app/Actions/PasteReleaseNotesAtTheTop.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\CreateNewReleaseHeading;
+use App\Exceptions\ReleaseNotesCanNotBeplacedException;
 use App\Exceptions\ReleaseNotesNotProvidedException;
 use App\MarkdownParser;
 use App\Queries\FindFirstSecondLevelHeading;
@@ -43,8 +44,10 @@ class PasteReleaseNotesAtTheTop
         if ($previousVersionHeading !== null) {
             // Insert the newest Release Notes before the previous Release Heading
             $previousVersionHeading->insertBefore($parsedReleaseNotes);
+        } elseif ($changelog->lastChild() !== null) {
+            $changelog->lastChild()->insertAfter($parsedReleaseNotes);
         } else {
-            $changelog->lastChild()?->insertAfter($parsedReleaseNotes);
+            throw new ReleaseNotesCanNotBeplacedException();
         }
 
         return $changelog;

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -6,6 +6,7 @@ namespace App\Commands;
 
 use App\Actions\AddReleaseNotesToChangelog;
 use App\Exceptions\ReleaseAlreadyExistsInChangelogException;
+use App\Exceptions\ReleaseNotesCanNotBeplacedException;
 use App\Exceptions\ReleaseNotesNotProvidedException;
 use App\Support\GitHubActionsOutput;
 use LaravelZero\Framework\Commands\Command;
@@ -55,6 +56,7 @@ class UpdateCommand extends Command
                 compareUrlTargetRevision: $compareUrlTargetRevision
             );
             $this->info($updatedChangelog->getContent());
+
             $this->writeChangelogToFile($pathToChangelog, $updatedChangelog);
 
             return self::SUCCESS;
@@ -62,7 +64,7 @@ class UpdateCommand extends Command
             $this->warn($exception->getMessage());
 
             return self::SUCCESS;
-        } catch (ReleaseNotesNotProvidedException $exception) {
+        } catch (ReleaseNotesNotProvidedException|ReleaseNotesCanNotBeplacedException $exception) {
             $this->error($exception->getMessage());
 
             return self::FAILURE;

--- a/app/Exceptions/ReleaseNotesCanNotBeplacedException.php
+++ b/app/Exceptions/ReleaseNotesCanNotBeplacedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exceptions;
 
 use Exception;

--- a/app/Exceptions/ReleaseNotesCanNotBeplacedException.php
+++ b/app/Exceptions/ReleaseNotesCanNotBeplacedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class ReleaseNotesCanNotBeplacedException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct("Release notes could not be placed. Is the CHANGELOG empty? Does it contain at least one heading?");
+    }
+}

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -241,3 +241,24 @@ it('nothing happens if no release notes have been given and no unreleased headin
          ->expectsOutput('Release Notes were not provided. Pass them through the `--release-notes`-option.')
          ->assertFailed();
 });
+
+test('it shows warning if changelog is empty and content can not be placed', function () {
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/empty-changelog.md',
+        '--compare-url-target-revision' => 'HEAD',
+    ])
+         ->expectsOutput('Release notes could not be placed. Is the CHANGELOG empty? Does it contain at least one heading?')
+         ->assertFailed();
+});


### PR DESCRIPTION
Fixes an issue where the CLI silently failed when the release notes could not be placed due to a missing child in the parsed Markdown AST – eg. the CHANGELOG file is empty.