### PR TITLE
Shift Headings to Release Notes to always be at least level 3 headings

### DIFF
--- a/app/Actions/PasteReleaseNotesAtTheTop.php
+++ b/app/Actions/PasteReleaseNotesAtTheTop.php
@@ -17,12 +17,14 @@ class PasteReleaseNotesAtTheTop
     private FindFirstSecondLevelHeading $findFirstSecondLevelHeading;
     private MarkdownParser $parser;
     private CreateNewReleaseHeading $createNewReleaseHeading;
+    private ShiftHeadingLevelInDocument $shiftHeadingLevelInDocument;
 
-    public function __construct(FindFirstSecondLevelHeading $findFirstSecondLevelHeading, MarkdownParser $markdownParser, CreateNewReleaseHeading $createNewReleaseHeading)
+    public function __construct(FindFirstSecondLevelHeading $findFirstSecondLevelHeading, MarkdownParser $markdownParser, CreateNewReleaseHeading $createNewReleaseHeading, ShiftHeadingLevelInDocument $shiftHeadingLevelInDocumentt)
     {
         $this->findFirstSecondLevelHeading = $findFirstSecondLevelHeading;
         $this->parser = $markdownParser;
         $this->createNewReleaseHeading = $createNewReleaseHeading;
+        $this->shiftHeadingLevelInDocument = $shiftHeadingLevelInDocumentt;
     }
 
     /**
@@ -36,6 +38,11 @@ class PasteReleaseNotesAtTheTop
 
         // Prepend the new Release Heading to the Release Notes
         $parsedReleaseNotes = $this->parser->parse($releaseNotes);
+        $parsedReleaseNotes = $this->shiftHeadingLevelInDocument->execute(
+            document: $parsedReleaseNotes,
+            baseHeadingLevel: 3
+        );
+
         $parsedReleaseNotes->prependChild($newReleaseHeading);
 
         // Find the Heading of the previous Version

--- a/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
+++ b/app/Actions/PasteReleaseNotesBelowUnreleasedHeading.php
@@ -23,19 +23,22 @@ class PasteReleaseNotesBelowUnreleasedHeading
     private FindSecondLevelHeadingWithText $findPreviousVersionHeading;
     private CreateNewReleaseHeadingWithCompareUrl $createNewReleaseHeading;
     private GitHubActionsOutput $gitHubActionsOutput;
+    private ShiftHeadingLevelInDocument $shiftHeadingLevelInDocument;
 
     public function __construct(
         MarkdownParser                        $markdownParser,
         GenerateCompareUrl                    $generateCompareUrl,
         FindSecondLevelHeadingWithText        $findPreviousVersionHeading,
         CreateNewReleaseHeadingWithCompareUrl $createNewReleaseHeading,
-        GitHubActionsOutput                   $gitHubActionsOutput
+        GitHubActionsOutput                   $gitHubActionsOutput,
+        ShiftHeadingLevelInDocument $shiftHeadingLevelInDocument
     ) {
         $this->parser = $markdownParser;
         $this->generateCompareUrl = $generateCompareUrl;
         $this->findPreviousVersionHeading = $findPreviousVersionHeading;
         $this->createNewReleaseHeading = $createNewReleaseHeading;
         $this->gitHubActionsOutput = $gitHubActionsOutput;
+        $this->shiftHeadingLevelInDocument = $shiftHeadingLevelInDocument;
     }
 
     /**
@@ -62,6 +65,11 @@ class PasteReleaseNotesBelowUnreleasedHeading
 
             // Prepend the new Release Heading to the Release Notes
             $parsedReleaseNotes = $this->parser->parse($releaseNotes);
+            $parsedReleaseNotes = $this->shiftHeadingLevelInDocument->execute(
+                document: $parsedReleaseNotes,
+                baseHeadingLevel: 3
+            );
+
             $parsedReleaseNotes->prependChild($newReleaseHeading);
 
             // Find the Heading of the previous Version

--- a/app/Actions/ShiftHeadingLevelInDocument.php
+++ b/app/Actions/ShiftHeadingLevelInDocument.php
@@ -24,7 +24,6 @@ class ShiftHeadingLevelInDocument
                 continue;
             }
 
-            // $heading->setLevel($heading->getLevel() + ($baseHeadingLevel - $heading->getLevel()));
             $heading->setLevel($baseHeadingLevel);
         }
 

--- a/app/Actions/ShiftHeadingLevelInDocument.php
+++ b/app/Actions/ShiftHeadingLevelInDocument.php
@@ -50,6 +50,7 @@ class ShiftHeadingLevelInDocument
                 if ($level === null) {
                     return $heading->getLevel();
                 }
+
                 return min($level, $heading->getLevel());
             },
             null

--- a/app/Actions/ShiftHeadingLevelInDocument.php
+++ b/app/Actions/ShiftHeadingLevelInDocument.php
@@ -10,7 +10,7 @@ use League\CommonMark\Node\Query;
 
 class ShiftHeadingLevelInDocument
 {
-    public function execute(Document $document, int $minLevel): Document
+    public function execute(Document $document, int $baseHeadingLevel): Document
     {
         $headings = (new Query())
             ->where(Query::type(Heading::class))
@@ -19,12 +19,14 @@ class ShiftHeadingLevelInDocument
         /** @var Heading $heading */
         foreach ($headings as $heading) {
 
-            $currentHeadingLevel = $heading->getLevel();
-            $diffToDesiredLevel = $minLevel - $currentHeadingLevel;
-
-            if ($heading->getLevel() <= $minLevel) {
-                $heading->setLevel($heading->getLevel() + $diffToDesiredLevel);
+            // Don't shift heading if level is above base level
+            if ($heading->getLevel() >= $baseHeadingLevel) {
+                continue;
             }
+
+            // TODO: Should we keep the hierarchy of all headings intact?
+            $diffToDesiredLevel = $baseHeadingLevel - $heading->getLevel();
+            $heading->setLevel($heading->getLevel() + $diffToDesiredLevel);
         }
 
         return $document;

--- a/app/Actions/ShiftHeadingLevelInDocument.php
+++ b/app/Actions/ShiftHeadingLevelInDocument.php
@@ -24,9 +24,8 @@ class ShiftHeadingLevelInDocument
                 continue;
             }
 
-            // TODO: Should we keep the hierarchy of all headings intact?
-            $diffToDesiredLevel = $baseHeadingLevel - $heading->getLevel();
-            $heading->setLevel($heading->getLevel() + $diffToDesiredLevel);
+            // $heading->setLevel($heading->getLevel() + ($baseHeadingLevel - $heading->getLevel()));
+            $heading->setLevel($baseHeadingLevel);
         }
 
         return $document;

--- a/app/Actions/ShiftHeadingLevelInDocument.php
+++ b/app/Actions/ShiftHeadingLevelInDocument.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Node\Query;
+
+class ShiftHeadingLevelInDocument
+{
+    public function execute(Document $document, int $minLevel): Document
+    {
+        $headings = (new Query())
+            ->where(Query::type(Heading::class))
+            ->findAll($document);
+
+        /** @var Heading $heading */
+        foreach ($headings as $heading) {
+
+            $currentHeadingLevel = $heading->getLevel();
+            $diffToDesiredLevel = $minLevel - $currentHeadingLevel;
+
+            if ($heading->getLevel() <= $minLevel) {
+                $heading->setLevel($heading->getLevel() + $diffToDesiredLevel);
+            }
+        }
+
+        return $document;
+    }
+}

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -306,4 +306,4 @@ test('it automatically shifts heading levels to be level 3 headings to fit into 
         #### Removes
         - Remove Feature D
         MD,
-])->only();
+]);

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -278,10 +278,10 @@ test('it automatically shifts heading levels to be level 3 headings to fit into 
         - New Feature A
         - New Feature B
 
-        ## Changed
+        # Changed
         - Update Feature C
 
-        #### Removes
+        ## Removes
         - Remove Feature D
         MD,
     'starts with h2' => <<<MD
@@ -289,21 +289,10 @@ test('it automatically shifts heading levels to be level 3 headings to fit into 
         - New Feature A
         - New Feature B
 
-        ### Changed
+        ## Changed
         - Update Feature C
 
-        #### Removes
-        - Remove Feature D
-        MD,
-    'starts with h3' => <<<MD
-        ### Added
-        - New Feature A
-        - New Feature B
-
-        ### Changed
-        - Update Feature C
-
-        #### Removes
+        ### Removes
         - Remove Feature D
         MD,
 ]);

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -262,3 +262,24 @@ test('it shows warning if changelog is empty and content can not be placed', fun
          ->expectsOutput('Release notes could not be placed. Is the CHANGELOG empty? Does it contain at least one heading?')
          ->assertFailed();
 });
+
+test('it automatically shifts heading levels to be level 3 headings to fit into the existing changelog', function () {
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ## Added
+        - New Feature A
+        - New Feature B
+
+        ## Changed
+        - Update Feature C
+
+        ## Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
+        '--release-date' => '2021-02-01',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog.md'))
+         ->assertSuccessful();
+});

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -263,23 +263,48 @@ test('it shows warning if changelog is empty and content can not be placed', fun
          ->assertFailed();
 });
 
-test('it automatically shifts heading levels to be level 3 headings to fit into the existing changelog', function () {
+test('it automatically shifts heading levels to be level 3 headings to fit into the existing changelog', function ($releaseNotes) {
+
     $this->artisan('update', [
-        '--release-notes' => <<<MD
-        ## Added
+        '--release-notes' => $releaseNotes,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
+        '--release-date' => '2021-02-01',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-shifted-headings.md'))
+         ->assertSuccessful();
+})->with([
+    'starts with h1' => <<<MD
+        # Added
         - New Feature A
         - New Feature B
 
         ## Changed
         - Update Feature C
 
-        ## Removes
+        #### Removes
         - Remove Feature D
         MD,
-        '--latest-version' => 'v1.0.0',
-        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
-        '--release-date' => '2021-02-01',
-    ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog.md'))
-         ->assertSuccessful();
-});
+    'starts with h2' => <<<MD
+        ## Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        #### Removes
+        - Remove Feature D
+        MD,
+    'starts with h3' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        #### Removes
+        - Remove Feature D
+        MD,
+])->only();

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -264,7 +264,6 @@ test('it shows warning if changelog is empty and content can not be placed', fun
 });
 
 test('it automatically shifts heading levels to be level 3 headings to fit into the existing changelog', function ($releaseNotes) {
-
     $this->artisan('update', [
         '--release-notes' => $releaseNotes,
         '--latest-version' => 'v1.0.0',

--- a/tests/Stubs/expected-changelog-with-shifted-headings.md
+++ b/tests/Stubs/expected-changelog-with-shifted-headings.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/org/repo/compare/v1.0.0...HEAD)
+
+Please do not update the unreleased notes.
+
+<!-- Content should be placed here -->
+## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+#### Removes
+
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+
+- Initial Release

--- a/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
+++ b/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Actions\ShiftHeadingLevelInDocument;
 use App\MarkdownParser;
 use App\MarkdownRenderer;
 
 test('shifts headings to be below min heading level', function () {
-
     $document = app(MarkdownParser::class)->parse(<<<MD
     # Level 1 Heading
 
@@ -34,5 +35,4 @@ test('shifts headings to be below min heading level', function () {
 ##### Level 5 Heading
 MD
 , trim($updatedDocument->getContent()));
-
 });

--- a/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
+++ b/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Actions\ShiftHeadingLevelInDocument;
+use App\MarkdownParser;
+use App\MarkdownRenderer;
+
+test('shifts headings to be below min heading level', function () {
+
+    $document = app(MarkdownParser::class)->parse(<<<MD
+    # Level 1 Heading
+
+    ## Level 2 Heading
+
+    ### Level 3 Heading
+
+    #### Level 4 Heading
+
+    ##### Level 5 Heading
+    MD);
+
+    $result = app(ShiftHeadingLevelInDocument::class)->execute($document, 3);
+
+    $updatedDocument = app(MarkdownRenderer::class)->render($result);
+
+    $this->assertEquals(<<<MD
+### Level 1 Heading
+
+### Level 2 Heading
+
+### Level 3 Heading
+
+#### Level 4 Heading
+
+##### Level 5 Heading
+MD
+, trim($updatedDocument->getContent()));
+
+});

--- a/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
+++ b/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
@@ -36,3 +36,38 @@ test('shifts headings to be below min heading level', function () {
 MD
 , trim($updatedDocument->getContent()));
 });
+
+test('shifts headings and keeps hierarchy', function () {
+    $document = app(MarkdownParser::class)->parse(<<<MD
+    # Level 1 becomes Level 2
+
+    ## Level 2 becomes Level 3
+
+    ### Level 3 becomes Level 4
+
+    #### Level 4 becomes Level 5
+
+    ##### Level 5 becomes Level 6
+
+    ###### Level 6 becomes Level 6
+    MD);
+
+    $result = app(ShiftHeadingLevelInDocument::class)->execute($document, 2);
+
+    $updatedDocument = app(MarkdownRenderer::class)->render($result);
+
+    $this->assertEquals(<<<MD
+## Level 1 becomes Level 2
+
+### Level 2 becomes Level 3
+
+#### Level 3 becomes Level 4
+
+##### Level 4 becomes Level 5
+
+###### Level 5 becomes Level 6
+
+###### Level 6 becomes Level 6
+MD
+, trim($updatedDocument->getContent()));
+})->skip("Not implemented yet, maybe something for the future");

--- a/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
+++ b/tests/Unit/Actions/ShiftHeadingLevelInDocumentTest.php
@@ -23,18 +23,20 @@ test('shifts headings to be below min heading level', function () {
 
     $updatedDocument = app(MarkdownRenderer::class)->render($result);
 
-    $this->assertEquals(<<<MD
-### Level 1 Heading
+    expect(trim($updatedDocument->getContent()))
+        ->toEqual(
+            <<<MD
+            ### Level 1 Heading
 
-### Level 2 Heading
+            #### Level 2 Heading
 
-### Level 3 Heading
+            ##### Level 3 Heading
 
-#### Level 4 Heading
+            ###### Level 4 Heading
 
-##### Level 5 Heading
-MD
-, trim($updatedDocument->getContent()));
+            ###### Level 5 Heading
+            MD,
+        );
 });
 
 test('shifts headings and keeps hierarchy', function () {
@@ -56,18 +58,20 @@ test('shifts headings and keeps hierarchy', function () {
 
     $updatedDocument = app(MarkdownRenderer::class)->render($result);
 
-    $this->assertEquals(<<<MD
-## Level 1 becomes Level 2
+    expect(trim($updatedDocument->getContent()))
+        ->toEqual(
+            <<<MD
+            ## Level 1 becomes Level 2
 
-### Level 2 becomes Level 3
+            ### Level 2 becomes Level 3
 
-#### Level 3 becomes Level 4
+            #### Level 3 becomes Level 4
 
-##### Level 4 becomes Level 5
+            ##### Level 4 becomes Level 5
 
-###### Level 5 becomes Level 6
+            ###### Level 5 becomes Level 6
 
-###### Level 6 becomes Level 6
-MD
-, trim($updatedDocument->getContent()));
-})->skip("Not implemented yet, maybe something for the future");
+            ###### Level 6 becomes Level 6
+            MD
+        );
+});


### PR DESCRIPTION
This PR adds a new internal Action to Shift headings contained in the incoming release notes to be at least level 3 headings.

For example, the following release notes markdown …

```md
## Added
- New Feature A

## Changed
- Update Feature C

## Removes
- Remove Feature D
```

is converted to this:

```md
### Added
- New Feature A
- New Feature B

### Changed
- Update Feature C

### Removes
- Remove Feature D
```

The PR currently only shifts headings below level 3 (H1 and H2). This breaks the hierarchy, if for example H3 headings are also present in the release notes.
Still figuring out, if it would make sense to shift **all** headings automatically.

refs #22 