### PR TITLE
Add `--heading-text` option to manipulate heading text

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If a given version already exists in the CHANGELOG, the CLI will display a warni
 **Required**. The release notes you want to add to your changelog. Should be markdown.
 
 ### `--latest-version`
-**Required**. Version number of the latest release. The value will be used as the heading text. If the changelog has a "Unreleased" heading, the value will be used in the updated compare URL.
+**Required**. Version number of the latest release. The value will be used as the heading text if `--heading-text` is not set. If the changelog has a "Unreleased" heading, the value will be used in the updated compare URL.
 
 Example: `v1.0.0`
 
@@ -70,6 +70,14 @@ Optional. Write the changes to `CHANGELOG.md` or to the value of `--path-to-chan
 
 ### `--github-actions-output`
 Optional. Will output values for `UNRELEASED_COMPARE_URL` and `RELEASE_COMPARE_URL` that can be picked up by GitHub Actions and further used in ones Workflow. 
+
+### `--heading-text`
+Optional (Defaults to value of `--latest-version`). The text value used in the heading that is created for the new release. 
+
+```md
+## heading-text - 2021-02-01
+## [heading-text](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
+```
 
 ## Expected Changelog Formats
 

--- a/app/Actions/AddReleaseNotesToChangelogAction.php
+++ b/app/Actions/AddReleaseNotesToChangelogAction.php
@@ -26,7 +26,7 @@ class AddReleaseNotesToChangelogAction
     /**
      * @throws Throwable
      */
-    public function execute(string $originalChangelog, ?string $releaseNotes, string $latestVersion, string $releaseDate, string $compareUrlTargetRevision): RenderedContentInterface
+    public function execute(string $originalChangelog, string $latestVersion, string $headingText, ?string $releaseNotes, string $releaseDate, string $compareUrlTargetRevision): RenderedContentInterface
     {
         $changelog = $this->markdown->parse($originalChangelog);
 
@@ -38,6 +38,7 @@ class AddReleaseNotesToChangelogAction
             $changelog = $this->addNewReleaseNotesWithUnreleasedHeadingToChangelog->execute(
                 unreleasedHeading: $unreleasedHeading,
                 latestVersion: $latestVersion,
+                headingText: $headingText,
                 releaseDate: $releaseDate,
                 releaseNotes: $releaseNotes,
                 changelog: $changelog,
@@ -47,6 +48,7 @@ class AddReleaseNotesToChangelogAction
             $changelog = $this->addNewReleaseToChangelog->execute(
                 changelog: $changelog,
                 latestVersion: $latestVersion,
+                headingText: $headingText,
                 releaseDate: $releaseDate,
                 releaseNotes: $releaseNotes
             );

--- a/app/Actions/AddReleaseNotesToChangelogAction.php
+++ b/app/Actions/AddReleaseNotesToChangelogAction.php
@@ -47,7 +47,6 @@ class AddReleaseNotesToChangelogAction
         } else {
             $changelog = $this->addNewReleaseToChangelog->execute(
                 changelog: $changelog,
-                latestVersion: $latestVersion,
                 headingText: $headingText,
                 releaseDate: $releaseDate,
                 releaseNotes: $releaseNotes

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -22,11 +22,11 @@ class PlaceReleaseNotesAtTheTopAction
     /**
      * @throws Throwable
      */
-    public function execute(Document $changelog, string $latestVersion, string $releaseDate, ?string $releaseNotes): Document
+    public function execute(Document $changelog, string $latestVersion, string $headingText, string $releaseDate, ?string $releaseNotes): Document
     {
         throw_if(empty($releaseNotes), ReleaseNotesNotProvidedException::class);
 
-        $newReleaseHeading = $this->createNewReleaseHeading->create($latestVersion, $releaseDate);
+        $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate);
 
         // Find the Heading of the previous Version
         $previousVersionHeading = $this->findFirstSecondLevelHeading->find($changelog);

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -22,7 +22,7 @@ class PlaceReleaseNotesAtTheTopAction
     /**
      * @throws Throwable
      */
-    public function execute(Document $changelog, string $latestVersion, string $headingText, string $releaseDate, ?string $releaseNotes): Document
+    public function execute(Document $changelog, string $headingText, string $releaseDate, ?string $releaseNotes): Document
     {
         throw_if(empty($releaseNotes), ReleaseNotesNotProvidedException::class);
 

--- a/app/Actions/PlaceReleaseNotesBelowUnreleasedHeadingAction.php
+++ b/app/Actions/PlaceReleaseNotesBelowUnreleasedHeadingAction.php
@@ -29,7 +29,7 @@ class PlaceReleaseNotesBelowUnreleasedHeadingAction
     /**
      * @throws Throwable
      */
-    public function execute(Heading $unreleasedHeading, string $latestVersion, string $releaseDate, ?string $releaseNotes, Document $changelog, string $compareUrlTargetRevision): Document
+    public function execute(Heading $unreleasedHeading, string $latestVersion, string $headingText, string $releaseDate, ?string $releaseNotes, Document $changelog, string $compareUrlTargetRevision): Document
     {
         $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($unreleasedHeading);
         $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($unreleasedHeading);
@@ -40,7 +40,7 @@ class PlaceReleaseNotesBelowUnreleasedHeadingAction
         $this->gitHubActionsOutput->add('UNRELEASED_COMPARE_URL', $updatedUrl);
 
         // Create new Heading containing the new version number
-        $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $releaseDate);
+        $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $headingText, $releaseDate);
 
         if (empty($releaseNotes)) {
             // If no Release Notes have been passed, add the new Release Heading below the updated Unreleased Heading.

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -56,8 +56,9 @@ class UpdateCommand extends Command
         try {
             $updatedChangelog = $addReleaseNotesToChangelog->execute(
                 originalChangelog: $changelog,
-                releaseNotes: $releaseNotes,
                 latestVersion: $latestVersion,
+                headingText: $headingText,
+                releaseNotes: $releaseNotes,
                 releaseDate: $releaseDate,
                 compareUrlTargetRevision: $compareUrlTargetRevision
             );

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -19,6 +19,7 @@ class UpdateCommand extends Command
     protected $signature = 'update
         {--release-notes= : Markdown Release Notes to be added to the CHANGELOG.}
         {--latest-version= : The version the CHANGELOG should be updated too.}
+        {--heading-text= : Text used in the new release heading. Defaults to the value from --latest-version.}
         {--release-date= : Date when latest version has been released. Defaults to today.}
         {--path-to-changelog=CHANGELOG.md : Path to changelog markdown file to be updated.}
         {--compare-url-target-revision=HEAD : Target revision used in the compare URL of possible "Unreleased" heading.}
@@ -40,9 +41,14 @@ class UpdateCommand extends Command
         $releaseDate = $this->option('release-date');
         $pathToChangelog = $this->option('path-to-changelog');
         $compareUrlTargetRevision = $this->option('compare-url-target-revision');
+        $headingText = $this->option('heading-text');
 
         if (empty($releaseDate)) {
             $releaseDate = now()->format('Y-m-d');
+        }
+
+        if (empty($headingText)) {
+            $headingText = $latestVersion;
         }
 
         $changelog = $this->getChangelogContent($pathToChangelog);

--- a/app/CreateNewReleaseHeadingWithCompareUrl.php
+++ b/app/CreateNewReleaseHeadingWithCompareUrl.php
@@ -19,14 +19,14 @@ class CreateNewReleaseHeadingWithCompareUrl
     ) {
     }
 
-    public function create(string $repositoryUrl, string $previousVersion, string $latestVersion, string $releaseDate): Heading
+    public function create(string $repositoryUrl, string $previousVersion, string $latestVersion, string $headingText, string $releaseDate): Heading
     {
         $url = $this->generateCompareUrl->generate($repositoryUrl, $previousVersion, $latestVersion);
 
         $this->gitHubActionsOutput->add('RELEASE_COMPARE_URL', $url);
 
-        return tap(new Heading(2), function (Heading $heading) use ($url, $latestVersion, $releaseDate) {
-            $heading->appendChild($this->createLinkNode($latestVersion, $url));
+        return tap(new Heading(2), function (Heading $heading) use ($headingText, $url, $releaseDate) {
+            $heading->appendChild($this->createLinkNode($headingText, $url));
             $heading->appendChild($this->createDateNode($releaseDate));
 
             $this->extractPermalinkFragmentFromHeading->execute($heading);

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -296,3 +296,47 @@ test('it automatically shifts heading levels to be level 3 headings to fit into 
         - Remove Feature D
         MD,
 ]);
+
+it('heading-text option allows user to use different heading text than latest-version when changelog contains unreleased heading', function () {
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
+        '--release-date' => '2021-02-01',
+        '--heading-text' => '::heading-text::',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-heading-text.md'))
+         ->assertSuccessful();
+});
+
+it('heading-text option allows user to use different heading text than latest-version when changelog does not contain unreleased heading', function () {
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
+        '--release-date' => '2021-02-01',
+        '--heading-text' => '::heading-text::',
+    ])
+         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased-with-heading-text.md'))
+         ->assertSuccessful();
+});

--- a/tests/Stubs/expected-changelog-with-heading-text.md
+++ b/tests/Stubs/expected-changelog-with-heading-text.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/org/repo/compare/v1.0.0...HEAD)
+
+Please do not update the unreleased notes.
+
+<!-- Content should be placed here -->
+## [::heading-text::](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+
+- Initial Release

--- a/tests/Stubs/expected-changelog-without-unreleased-with-heading-text.md
+++ b/tests/Stubs/expected-changelog-without-unreleased-with-heading-text.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## ::heading-text:: - 2021-02-01
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+
+- Initial Release

--- a/tests/Unit/CreateNewReleaseHeadingTest.php
+++ b/tests/Unit/CreateNewReleaseHeadingTest.php
@@ -15,6 +15,7 @@ test('creates new release heading ast', function () {
     $repositoryUrl = 'https://github.com/org/repo';
     $previousVersion = 'v0.1.0';
     $latestVersion = 'v1.0.0';
+    $headingText = $latestVersion;
     $releaseDate = '2021-02-01';
 
     $environment = new Environment();
@@ -26,6 +27,7 @@ test('creates new release heading ast', function () {
         $repositoryUrl,
         $previousVersion,
         $latestVersion,
+        $headingText,
         $releaseDate
     );
 


### PR DESCRIPTION
This PR adds a new `--heading-text` option to change the text of the release heading (currently defaults to the value of `--latest-version`).

This change allows users to pass an arbitrary value as the heading, if they don't want to use the tag name as the heading name.

## Related issues

- https://github.com/stefanzweifel/changelog-updater-action/issues/19