### PR TITLE
Update CLI to use new GITHUB_OUTPUT environment

### DIFF
--- a/app/Support/GitHubActionsOutput.php
+++ b/app/Support/GitHubActionsOutput.php
@@ -16,7 +16,11 @@ class GitHubActionsOutput extends MessageBag
 
             if ($this->hasGithubOutputEnvironment()) {
                 $this->setOutput($key, $value);
-            } else {
+            }
+
+            // Set output variables using old syntax for compatibility with older versions of GitHub Actions runner.
+            // Stops working in 2023.
+            if (now()->year < 2023) {
                 $output->text(sprintf("::set-output name=%s::%s", $key, $value));
             }
         }

--- a/app/Support/GitHubActionsOutput.php
+++ b/app/Support/GitHubActionsOutput.php
@@ -26,7 +26,7 @@ class GitHubActionsOutput extends MessageBag
         }
     }
 
-    public function setOutput($name, $value): void
+    private function setOutput($name, $value): void
     {
         $pathToGitHubOutput = getenv('GITHUB_OUTPUT');
         $gitHubOutput = file_get_contents($pathToGitHubOutput);

--- a/app/Support/GitHubActionsOutput.php
+++ b/app/Support/GitHubActionsOutput.php
@@ -12,7 +12,30 @@ class GitHubActionsOutput extends MessageBag
     public function render(OutputStyle $output): void
     {
         foreach ($this->messages() as $key => $message) {
-            $output->text(sprintf("::set-output name=%s::%s", $key, head($message)));
+            $value = head($message);
+
+            if ($this->hasGithubOutputEnvironment()) {
+                $this->setOutput($key, $value);
+            } else {
+                $output->text(sprintf("::set-output name=%s::%s", $key, $value));
+            }
         }
+    }
+
+    public function setOutput($name, $value): void
+    {
+        $pathToGitHubOutput = getenv('GITHUB_OUTPUT');
+        $gitHubOutput = file_get_contents($pathToGitHubOutput);
+
+        $gitHubOutput .= "$name=$value\n";
+
+        file_put_contents($pathToGitHubOutput, $gitHubOutput, FILE_APPEND | LOCK_EX);
+    }
+
+    private function hasGithubOutputEnvironment(): bool
+    {
+        $gitHubOutput = getenv('GITHUB_OUTPUT');
+
+        return ! empty($gitHubOutput);
     }
 }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -21,16 +21,10 @@ trait CreatesApplication
 
         $this->gitHubOutputTestfile = base_path('tests/github_output.txt');
 
-        // Can be enabled by default, once the old set-output syntax has been removed.
-        // $this->hasGitHubOutputEnvironment();
+        putenv("GITHUB_OUTPUT=$this->gitHubOutputTestfile");
 
         $app->make(Kernel::class)->bootstrap();
 
         return $app;
-    }
-
-    public function hasGitHubOutputEnvironment()
-    {
-        putenv("GITHUB_OUTPUT=$this->gitHubOutputTestfile");
     }
 }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -8,6 +8,8 @@ use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
 {
+    public readonly string $gitHubOutputTestfile;
+
     /**
      * Creates the application.
      *
@@ -17,8 +19,18 @@ trait CreatesApplication
     {
         $app = require __DIR__.'/../bootstrap/app.php';
 
+        $this->gitHubOutputTestfile = base_path('tests/github_output.txt');
+
+        // Can be enabled by default, once the old set-output syntax has been removed.
+        // $this->hasGitHubOutputEnvironment();
+
         $app->make(Kernel::class)->bootstrap();
 
         return $app;
+    }
+
+    public function hasGitHubOutputEnvironment()
+    {
+        putenv("GITHUB_OUTPUT=$this->gitHubOutputTestfile");
     }
 }

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -19,8 +19,8 @@ it('places given release notes in correct position in given markdown changelog',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
         '--release-date' => '2021-02-01',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog.md'))
+        ->assertSuccessful();
 });
 
 it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in CI environment', function () {
@@ -41,17 +41,51 @@ it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in
         '--release-date' => '2021-02-01',
         '--github-actions-output' => true,
     ])
-         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
-         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_URL_FRAGMENT', '#v100---2021-02-01'))
-         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
-         ->assertSuccessful();
+        ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
+        ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_URL_FRAGMENT', '#v100---2021-02-01'))
+        ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
+        ->assertSuccessful();
+
+    $this->assertGitHubOutputDoesntContain('RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0');
+    $this->assertGitHubOutputDoesntContain('RELEASE_URL_FRAGMENT', '#v100---2021-02-01');
+    $this->assertGitHubOutputDoesntContain('UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD');
+});
+
+it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL to GITHUB_OUTPUT environment', function () {
+    $this->hasGitHubOutputEnvironment();
+
+    $this->artisan('update', [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
+        '--release-date' => '2021-02-01',
+        '--github-actions-output' => true,
+    ])
+        ->doesntExpectOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
+        ->doesntExpectOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_URL_FRAGMENT', '#v100---2021-02-01'))
+        ->doesntExpectOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
+        ->assertSuccessful();
+
+    $this->assertGitHubOutputContains('RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0');
+    $this->assertGitHubOutputContains('RELEASE_URL_FRAGMENT', '#v100---2021-02-01');
+    $this->assertGitHubOutputContains('UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD');
 });
 
 it('throws error if latest-version is missing', function () {
     $this->artisan('update', [
         '--release-notes' => '::release-notes::',
-        ])
-       ->assertFailed();
+    ])
+        ->assertFailed();
 })->throws(InvalidArgumentException::class, 'No latest-version option provided. Abort.');
 
 it('uses current date for release date if no option is provieded', function () {
@@ -73,8 +107,8 @@ it('uses current date for release date if no option is provieded', function () {
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
     ])
-         ->expectsOutput($expectedOutput)
-         ->assertSuccessful();
+        ->expectsOutput($expectedOutput)
+        ->assertSuccessful();
 });
 
 it('uses current date for release date if option is empty', function () {
@@ -97,8 +131,8 @@ it('uses current date for release date if option is empty', function () {
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
         '--release-date' => '',
     ])
-         ->expectsOutput($expectedOutput)
-         ->assertSuccessful();
+        ->expectsOutput($expectedOutput)
+        ->assertSuccessful();
 });
 
 it('places given release notes in correct position in given markdown changelog when no unreleased heading is available', function () {
@@ -118,8 +152,8 @@ it('places given release notes in correct position in given markdown changelog w
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
         '--release-date' => '2021-02-01',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased.md'))
+        ->assertSuccessful();
 });
 
 it('places given release notes in correct position in given markdown changelog when no heading is available', function () {
@@ -139,8 +173,8 @@ it('places given release notes in correct position in given markdown changelog w
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-headings.md',
         '--release-date' => '2021-02-01',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-headings.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-headings.md'))
+        ->assertSuccessful();
 });
 
 it('places given release notes in correct position even if changelog is empty besides an unreleased heading', function () {
@@ -160,8 +194,8 @@ it('places given release notes in correct position even if changelog is empty be
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-empty-with-unreleased.md',
         '--release-date' => '2021-02-01',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-empty-with-unreleased.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-empty-with-unreleased.md'))
+        ->assertSuccessful();
 });
 
 it('uses compare-url-target option in unreleased heading url', function () {
@@ -182,8 +216,8 @@ it('uses compare-url-target option in unreleased heading url', function () {
         '--release-date' => '2021-02-01',
         '--compare-url-target-revision' => '1.x',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-custom-compare-url-target.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-custom-compare-url-target.md'))
+        ->assertSuccessful();
 });
 
 it('shows warning if version already exists in the changelog', function () {
@@ -204,8 +238,8 @@ it('shows warning if version already exists in the changelog', function () {
         '--release-date' => '2021-02-01',
         '--compare-url-target-revision' => '1.x',
     ])
-         ->expectsOutput('CHANGELOG was not updated as release notes for v0.1.0 already exist.')
-         ->assertSuccessful();
+        ->expectsOutput('CHANGELOG was not updated as release notes for v0.1.0 already exist.')
+        ->assertSuccessful();
 });
 
 it('uses existing content between unreleased and previous version heading as release notes if release notes are empty', function () {
@@ -216,8 +250,8 @@ it('uses existing content between unreleased and previous version heading as rel
         '--release-date' => '2021-02-01',
         '--compare-url-target-revision' => '1.x',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
+        ->assertSuccessful();
 });
 
 it('uses existing content between unreleased and previous version heading as release notes if release notes option is not provided', function () {
@@ -227,8 +261,8 @@ it('uses existing content between unreleased and previous version heading as rel
         '--release-date' => '2021-02-01',
         '--compare-url-target-revision' => '1.x',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
+        ->assertSuccessful();
 });
 
 it('nothing happens if no release notes have been given and no unreleased heading can be found', function () {
@@ -238,8 +272,8 @@ it('nothing happens if no release notes have been given and no unreleased headin
         '--release-date' => '2021-02-01',
         '--compare-url-target-revision' => '1.x',
     ])
-         ->expectsOutput('Release Notes were not provided. Pass them through the `--release-notes`-option.')
-         ->assertFailed();
+        ->expectsOutput('Release Notes were not provided. Pass them through the `--release-notes`-option.')
+        ->assertFailed();
 });
 
 test('it shows warning if changelog is empty and content can not be placed', function () {
@@ -259,8 +293,8 @@ test('it shows warning if changelog is empty and content can not be placed', fun
         '--path-to-changelog' => __DIR__ . '/../Stubs/empty-changelog.md',
         '--compare-url-target-revision' => 'HEAD',
     ])
-         ->expectsOutput('Release notes could not be placed. Is the CHANGELOG empty? Does it contain at least one heading?')
-         ->assertFailed();
+        ->expectsOutput('Release notes could not be placed. Is the CHANGELOG empty? Does it contain at least one heading?')
+        ->assertFailed();
 });
 
 test('it automatically shifts heading levels to be level 3 headings to fit into the existing changelog', function ($releaseNotes) {
@@ -270,8 +304,8 @@ test('it automatically shifts heading levels to be level 3 headings to fit into 
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
         '--release-date' => '2021-02-01',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-shifted-headings.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-shifted-headings.md'))
+        ->assertSuccessful();
 })->with([
     'starts with h1' => <<<MD
         # Added
@@ -315,8 +349,8 @@ it('heading-text option allows user to use different heading text than latest-ve
         '--release-date' => '2021-02-01',
         '--heading-text' => '::heading-text::',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-heading-text.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-heading-text.md'))
+        ->assertSuccessful();
 });
 
 it('heading-text option allows user to use different heading text than latest-version when changelog does not contain unreleased heading', function () {
@@ -337,6 +371,6 @@ it('heading-text option allows user to use different heading text than latest-ve
         '--release-date' => '2021-02-01',
         '--heading-text' => '::heading-text::',
     ])
-         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased-with-heading-text.md'))
-         ->assertSuccessful();
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased-with-heading-text.md'))
+        ->assertSuccessful();
 });

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -45,15 +45,11 @@ it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in
         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_URL_FRAGMENT', '#v100---2021-02-01'))
         ->expectsOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
         ->assertSuccessful();
-
-    $this->assertGitHubOutputDoesntContain('RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0');
-    $this->assertGitHubOutputDoesntContain('RELEASE_URL_FRAGMENT', '#v100---2021-02-01');
-    $this->assertGitHubOutputDoesntContain('UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD');
+})->skip(function () {
+    return now()->year > 2022;
 });
 
 it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL to GITHUB_OUTPUT environment', function () {
-    $this->hasGitHubOutputEnvironment();
-
     $this->artisan('update', [
         '--release-notes' => <<<MD
         ### Added
@@ -70,11 +66,7 @@ it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL to GITHUB_OUTPUT envi
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
         '--release-date' => '2021-02-01',
         '--github-actions-output' => true,
-    ])
-        ->doesntExpectOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
-        ->doesntExpectOutputToContain(sprintf("::set-output name=%s::%s", 'RELEASE_URL_FRAGMENT', '#v100---2021-02-01'))
-        ->doesntExpectOutputToContain(sprintf("::set-output name=%s::%s", 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
-        ->assertSuccessful();
+    ])->assertSuccessful();
 
     $this->assertGitHubOutputContains('RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0');
     $this->assertGitHubOutputContains('RELEASE_URL_FRAGMENT', '#v100---2021-02-01');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,4 +9,21 @@ use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function tearDown(): void
+    {
+        file_put_contents($this->gitHubOutputTestfile, '');
+
+        parent::tearDown();
+    }
+
+    public function assertGitHubOutputContains($name, $value)
+    {
+        $this->assertStringContainsString("$name=$value", file_get_contents($this->gitHubOutputTestfile));
+    }
+
+    public function assertGitHubOutputDoesntContain($name, $value)
+    {
+        $this->assertStringNotContainsString("$name=$value", file_get_contents($this->gitHubOutputTestfile));
+    }
 }


### PR DESCRIPTION
Updates the CLI to support new GITHUB_OUTPUT environment to declare output variables.

Fixes https://github.com/stefanzweifel/changelog-updater-action/issues/25