### PR TITLE
Allow release-notes and latest-version options to be prompted

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Optional. Will output values for `UNRELEASED_COMPARE_URL` and `RELEASE_COMPARE_U
 ### `--heading-text`
 Optional (Defaults to value of `--latest-version`). The text value used in the heading that is created for the new release. 
 
+### `--parse-release-notes`
+Optional. Tell the CLI explicitly to use the content between an "Unreleased Heading" and the previous version heading as release notes. The value from `--release-notes` will be ignored.
+
 ```md
 ## heading-text - 2021-02-01
 ## [heading-text](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -18,6 +18,7 @@ class UpdateCommand extends Command
 {
     protected $signature = 'update
         {--release-notes= : Markdown Release Notes to be added to the CHANGELOG.}
+        {--parse-release-notes : Use existing Release Notes content between Unreleased and previous version heading.}
         {--latest-version= : The version the CHANGELOG should be updated too.}
         {--heading-text= : Text used in the new release heading. Defaults to the value from --latest-version.}
         {--release-date= : Date when latest version has been released. Defaults to today.}
@@ -85,11 +86,11 @@ class UpdateCommand extends Command
 
     protected function getReleaseNotes(): null | string
     {
-        if ( $this->hasOption('release-notes') ) {
-            return $this->option('release-notes') ?: $this->ask('What markdown Release Notes should be added to the CHANGELOG?');
+        if ( $this->option('parse-release-notes') ) {
+            return null;
         }
 
-        return null;
+        return $this->option('release-notes') ?: $this->ask('What markdown Release Notes should be added to the CHANGELOG?');
     }
 
     protected function getChangelogContent(string $pathToChangelog): bool | string

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -86,7 +86,7 @@ class UpdateCommand extends Command
 
     protected function getReleaseNotes(): null | string
     {
-        if ( $this->option('parse-release-notes') ) {
+        if ($this->option('parse-release-notes')) {
             return null;
         }
 

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -34,14 +34,15 @@ class UpdateCommand extends Command
      */
     public function handle(AddReleaseNotesToChangelogAction $addReleaseNotesToChangelog, GitHubActionsOutput $gitHubActionsOutput)
     {
-        $this->validateOptions();
-
-        $releaseNotes = $this->option('release-notes');
-        $latestVersion = $this->option('latest-version');
+        $latestVersion = $this->option('latest-version') ?: $this->ask('What version should the CHANGELOG should be updated too?');
+        $releaseNotes = $this->getReleaseNotes();
         $releaseDate = $this->option('release-date');
         $pathToChangelog = $this->option('path-to-changelog');
         $compareUrlTargetRevision = $this->option('compare-url-target-revision');
         $headingText = $this->option('heading-text');
+
+        Assert::stringNotEmpty($latestVersion, 'No latest-version option provided. Abort.');
+        Assert::fileExists($pathToChangelog, 'CHANGELOG file not found. Abort.');
 
         if (empty($releaseDate)) {
             $releaseDate = now()->format('Y-m-d');
@@ -82,10 +83,13 @@ class UpdateCommand extends Command
         }
     }
 
-    private function validateOptions(): void
+    protected function getReleaseNotes(): null | string
     {
-        Assert::stringNotEmpty($this->option('latest-version'), 'No latest-version option provided. Abort.');
-        Assert::fileExists($this->option('path-to-changelog'), 'CHANGELOG file not found. Abort.');
+        if ( $this->hasOption('release-notes') ) {
+            return $this->option('release-notes') ?: $this->ask('What markdown Release Notes should be added to the CHANGELOG?');
+        }
+
+        return null;
     }
 
     protected function getChangelogContent(string $pathToChangelog): bool | string

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -245,6 +245,20 @@ it('uses existing content between unreleased and previous version heading as rel
         ->assertSuccessful();
 });
 
+it('uses existing content between unreleased and previous version heading as release notes if release notes are empty parse-release notes is not given and command is run in no-interaction mode', function () {
+    $this->artisan(UpdateCommand::class, [
+        '--release-notes' => null,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-with-unreleased-notes.md',
+        '--release-date' => '2021-02-01',
+        '--compare-url-target-revision' => '1.x',
+        '--no-interaction' => true,
+    ])
+        ->expectsQuestion('What markdown Release Notes should be added to the CHANGELOG?', null)
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-with-unreleased-notes.md'))
+        ->assertSuccessful();
+});
+
 it('uses existing content between unreleased and previous version heading as release notes if release notes option is not provided', function () {
     $this->artisan(UpdateCommand::class, [
         '--parse-release-notes' => true,

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -271,13 +271,13 @@ it('uses existing content between unreleased and previous version heading as rel
         ->assertSuccessful();
 });
 
-it('asks question if no release notes have been given', function() {
+it('asks question if no release notes have been given', function () {
     $this->artisan(UpdateCommand::class, [
         '--release-notes' => '',
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
         '--release-date' => '2021-02-01',
-    ])->expectsQuestion('What markdown Release Notes should be added to the CHANGELOG?', '...');;
+    ])->expectsQuestion('What markdown Release Notes should be added to the CHANGELOG?', '...');
 });
 
 it('nothing happens if no release notes have been given and no unreleased heading can be found', function () {

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -73,12 +73,11 @@ it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL to GITHUB_OUTPUT envi
     $this->assertGitHubOutputContains('UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD');
 });
 
-it('throws error if latest-version is missing', function () {
+it('expects question if latest-version option is missing', function () {
     $this->artisan(UpdateCommand::class, [
         '--release-notes' => '::release-notes::',
-    ])
-        ->assertFailed();
-})->throws(InvalidArgumentException::class, 'No latest-version option provided. Abort.');
+    ])->expectsQuestion('What version should the CHANGELOG should be updated too?', 'v1.0.0');
+});
 
 it('uses current date for release date if no option is provieded', function () {
     $expectedChangelog = file_get_contents(__DIR__ . '/../Stubs/expected-changelog.md');
@@ -236,7 +235,7 @@ it('shows warning if version already exists in the changelog', function () {
 
 it('uses existing content between unreleased and previous version heading as release notes if release notes are empty', function () {
     $this->artisan(UpdateCommand::class, [
-        '--release-notes' => '',
+        '--parse-release-notes' => true,
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-with-unreleased-notes.md',
         '--release-date' => '2021-02-01',
@@ -248,6 +247,7 @@ it('uses existing content between unreleased and previous version heading as rel
 
 it('uses existing content between unreleased and previous version heading as release notes if release notes option is not provided', function () {
     $this->artisan(UpdateCommand::class, [
+        '--parse-release-notes' => true,
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-with-unreleased-notes.md',
         '--release-date' => '2021-02-01',
@@ -257,8 +257,18 @@ it('uses existing content between unreleased and previous version heading as rel
         ->assertSuccessful();
 });
 
+it('asks question if no release notes have been given', function() {
+    $this->artisan(UpdateCommand::class, [
+        '--release-notes' => '',
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
+        '--release-date' => '2021-02-01',
+    ])->expectsQuestion('What markdown Release Notes should be added to the CHANGELOG?', '...');;
+});
+
 it('nothing happens if no release notes have been given and no unreleased heading can be found', function () {
     $this->artisan(UpdateCommand::class, [
+        '--parse-release-notes' => true,
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
         '--release-date' => '2021-02-01',


### PR DESCRIPTION
Thanks for the CLI tool! ❤️

When using the update command between projects, copying/pasting release notes and quickly re-doing from command history - it would be great if the `--release-notes` and `--latest-version` options could be prompted and provided as regular input.

This PR fetches those values either over the normal options, or via two question prompts if the values aren't provided:

- What version should the CHANGELOG should be updated too?
- What markdown Release Notes should be added to the CHANGELOG?

Since empty `--release-notes` is a valid option (for using existing content between unreleased and previous version heading), and Symfony / Laravel console doesn't allow confirming if an option is simply present, this PR also adds the new `--parse-release-notes` to permit `null` release notes and the existing logic (rather than prompting).

Updated Pest tests to confirm logic and arguments.

Thanks!
