### PR TITLE
Add `--hide-release-date` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,16 @@ Optional. Will output values for `UNRELEASED_COMPARE_URL` and `RELEASE_COMPARE_U
 ### `--heading-text`
 Optional (Defaults to value of `--latest-version`). The text value used in the heading that is created for the new release. 
 
-### `--parse-release-notes`
-Optional. Tell the CLI explicitly to use the content between an "Unreleased Heading" and the previous version heading as release notes. The value from `--release-notes` will be ignored.
-
 ```md
 ## heading-text - 2021-02-01
 ## [heading-text](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
 ```
+
+### `--parse-release-notes`
+Optional. Tell the CLI explicitly to use the content between an "Unreleased Heading" and the previous version heading as release notes. The value from `--release-notes` will be ignored.
+
+### `--hide-date`
+Optional. Don't add the release date to the release heading.
 
 ## Expected Changelog Formats
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Optional (Defaults to value of `--latest-version`). The text value used in the h
 ### `--parse-release-notes`
 Optional. Tell the CLI explicitly to use the content between an "Unreleased Heading" and the previous version heading as release notes. The value from `--release-notes` will be ignored.
 
-### `--hide-date`
+### `--hide-release-date`
 Optional. Don't add the release date to the release heading.
 
 ## Expected Changelog Formats

--- a/app/Actions/AddReleaseNotesToChangelogAction.php
+++ b/app/Actions/AddReleaseNotesToChangelogAction.php
@@ -26,7 +26,7 @@ class AddReleaseNotesToChangelogAction
     /**
      * @throws Throwable
      */
-    public function execute(string $originalChangelog, string $latestVersion, string $headingText, ?string $releaseNotes, string $releaseDate, string $compareUrlTargetRevision): RenderedContentInterface
+    public function execute(string $originalChangelog, string $latestVersion, string $headingText, ?string $releaseNotes, string $releaseDate, string $compareUrlTargetRevision, bool $hideDate = false): RenderedContentInterface
     {
         $changelog = $this->markdown->parse($originalChangelog);
 
@@ -42,14 +42,16 @@ class AddReleaseNotesToChangelogAction
                 releaseDate: $releaseDate,
                 releaseNotes: $releaseNotes,
                 changelog: $changelog,
-                compareUrlTargetRevision: $compareUrlTargetRevision
+                compareUrlTargetRevision: $compareUrlTargetRevision,
+                hideDate: $hideDate
             );
         } else {
             $changelog = $this->addNewReleaseToChangelog->execute(
                 changelog: $changelog,
                 headingText: $headingText,
                 releaseDate: $releaseDate,
-                releaseNotes: $releaseNotes
+                releaseNotes: $releaseNotes,
+                hideDate: $hideDate,
             );
         }
 

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -22,11 +22,11 @@ class PlaceReleaseNotesAtTheTopAction
     /**
      * @throws Throwable
      */
-    public function execute(Document $changelog, string $headingText, string $releaseDate, ?string $releaseNotes): Document
+    public function execute(Document $changelog, string $headingText, string $releaseDate, ?string $releaseNotes, bool $hideDate = false): Document
     {
         throw_if(empty($releaseNotes), ReleaseNotesNotProvidedException::class);
 
-        $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate);
+        $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
 
         // Find the Heading of the previous Version
         $previousVersionHeading = $this->findFirstSecondLevelHeading->find($changelog);

--- a/app/Actions/PlaceReleaseNotesBelowUnreleasedHeadingAction.php
+++ b/app/Actions/PlaceReleaseNotesBelowUnreleasedHeadingAction.php
@@ -29,7 +29,7 @@ class PlaceReleaseNotesBelowUnreleasedHeadingAction
     /**
      * @throws Throwable
      */
-    public function execute(Heading $unreleasedHeading, string $latestVersion, string $headingText, string $releaseDate, ?string $releaseNotes, Document $changelog, string $compareUrlTargetRevision): Document
+    public function execute(Heading $unreleasedHeading, string $latestVersion, string $headingText, string $releaseDate, ?string $releaseNotes, Document $changelog, string $compareUrlTargetRevision, bool $hideDate = false): Document
     {
         $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($unreleasedHeading);
         $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($unreleasedHeading);
@@ -40,7 +40,7 @@ class PlaceReleaseNotesBelowUnreleasedHeadingAction
         $this->gitHubActionsOutput->add('UNRELEASED_COMPARE_URL', $updatedUrl);
 
         // Create new Heading containing the new version number
-        $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $headingText, $releaseDate);
+        $newReleaseHeading = $this->createNewReleaseHeading->create($repositoryUrl, $previousVersion, $latestVersion, $headingText, $releaseDate, $hideDate);
 
         if (empty($releaseNotes)) {
             // If no Release Notes have been passed, add the new Release Heading below the updated Unreleased Heading.

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -25,7 +25,7 @@ class UpdateCommand extends Command
         {--path-to-changelog=CHANGELOG.md : Path to changelog markdown file to be updated.}
         {--compare-url-target-revision=HEAD : Target revision used in the compare URL of possible "Unreleased" heading.}
         {--github-actions-output : Display GitHub Actions related output}
-        {--hide-date : Hide date in the new release heading.}
+        {--hide-release-date : Hide release date in the new release heading.}
         {-w\--write : Write changes to file}
     ';
 
@@ -42,7 +42,7 @@ class UpdateCommand extends Command
         $pathToChangelog = $this->option('path-to-changelog');
         $compareUrlTargetRevision = $this->option('compare-url-target-revision');
         $headingText = $this->option('heading-text');
-        $hideDate = $this->option('hide-date');
+        $hideDate = $this->option('hide-release-date');
 
         Assert::stringNotEmpty($latestVersion, 'No latest-version option provided. Abort.');
         Assert::fileExists($pathToChangelog, 'CHANGELOG file not found. Abort.');

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -25,6 +25,7 @@ class UpdateCommand extends Command
         {--path-to-changelog=CHANGELOG.md : Path to changelog markdown file to be updated.}
         {--compare-url-target-revision=HEAD : Target revision used in the compare URL of possible "Unreleased" heading.}
         {--github-actions-output : Display GitHub Actions related output}
+        {--hide-date : Hide date in the new release heading.}
         {-w\--write : Write changes to file}
     ';
 
@@ -41,6 +42,7 @@ class UpdateCommand extends Command
         $pathToChangelog = $this->option('path-to-changelog');
         $compareUrlTargetRevision = $this->option('compare-url-target-revision');
         $headingText = $this->option('heading-text');
+        $hideDate = $this->option('hide-date');
 
         Assert::stringNotEmpty($latestVersion, 'No latest-version option provided. Abort.');
         Assert::fileExists($pathToChangelog, 'CHANGELOG file not found. Abort.');
@@ -62,7 +64,8 @@ class UpdateCommand extends Command
                 headingText: $headingText,
                 releaseNotes: $releaseNotes,
                 releaseDate: $releaseDate,
-                compareUrlTargetRevision: $compareUrlTargetRevision
+                compareUrlTargetRevision: $compareUrlTargetRevision,
+                hideDate: $hideDate,
             );
             $this->info($updatedChangelog->getContent());
 

--- a/app/CreateNewReleaseHeading.php
+++ b/app/CreateNewReleaseHeading.php
@@ -14,11 +14,14 @@ class CreateNewReleaseHeading
     {
     }
 
-    public function create(string $text, string $releaseDate): Heading
+    public function create(string $text, string $releaseDate, bool $hideDate = false): Heading
     {
-        return tap(new Heading(2), function (Heading $heading) use ($text, $releaseDate) {
+        return tap(new Heading(2), function (Heading $heading) use ($hideDate, $text, $releaseDate) {
             $heading->appendChild(new Text($text));
-            $heading->appendChild(new Text(" - {$releaseDate}"));
+
+            if ($hideDate === false) {
+                $heading->appendChild(new Text(" - {$releaseDate}"));
+            }
 
             $this->extractPermalinkFragmentFromHeading->execute($heading);
         });

--- a/app/CreateNewReleaseHeadingWithCompareUrl.php
+++ b/app/CreateNewReleaseHeadingWithCompareUrl.php
@@ -19,15 +19,18 @@ class CreateNewReleaseHeadingWithCompareUrl
     ) {
     }
 
-    public function create(string $repositoryUrl, string $previousVersion, string $latestVersion, string $headingText, string $releaseDate): Heading
+    public function create(string $repositoryUrl, string $previousVersion, string $latestVersion, string $headingText, string $releaseDate, bool $hideDate = false): Heading
     {
         $url = $this->generateCompareUrl->generate($repositoryUrl, $previousVersion, $latestVersion);
 
         $this->gitHubActionsOutput->add('RELEASE_COMPARE_URL', $url);
 
-        return tap(new Heading(2), function (Heading $heading) use ($headingText, $url, $releaseDate) {
+        return tap(new Heading(2), function (Heading $heading) use ($hideDate, $headingText, $url, $releaseDate) {
             $heading->appendChild($this->createLinkNode($headingText, $url));
-            $heading->appendChild($this->createDateNode($releaseDate));
+
+            if ($hideDate === false) {
+                $heading->appendChild($this->createDateNode($releaseDate));
+            }
 
             $this->extractPermalinkFragmentFromHeading->execute($heading);
         });

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -443,3 +443,47 @@ it('writes changes to changelog to file', function () {
 
     file_put_contents(__DIR__ . '/../Stubs/base-changelog.md', $originalContent);
 });
+
+it('does not add date to release headings that have a compare url in it if --hide-date is passed', function () {
+    $this->artisan(UpdateCommand::class, [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
+        '--release-date' => '2021-02-01',
+        '--hide-date' => true,
+    ])
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-date.md'))
+        ->assertSuccessful();
+});
+
+it('does not add date to release heading if it does not contain a compare url and --hide-date option is passed', function () {
+    $this->artisan(UpdateCommand::class, [
+        '--release-notes' => <<<MD
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
+        '--release-date' => '2021-02-01',
+        '--hide-date' => true,
+    ])
+        ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased-without-date.md'))
+        ->assertSuccessful();
+});

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -444,7 +444,7 @@ it('writes changes to changelog to file', function () {
     file_put_contents(__DIR__ . '/../Stubs/base-changelog.md', $originalContent);
 });
 
-it('does not add date to release headings that have a compare url in it if --hide-date is passed', function () {
+it('does not add date to release headings that have a compare url in it if --hide-release-date is passed', function () {
     $this->artisan(UpdateCommand::class, [
         '--release-notes' => <<<MD
         ### Added
@@ -460,13 +460,13 @@ it('does not add date to release headings that have a compare url in it if --hid
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog.md',
         '--release-date' => '2021-02-01',
-        '--hide-date' => true,
+        '--hide-release-date' => true,
     ])
         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-date.md'))
         ->assertSuccessful();
 });
 
-it('does not add date to release heading if it does not contain a compare url and --hide-date option is passed', function () {
+it('does not add date to release heading if it does not contain a compare url and --hide-release-date option is passed', function () {
     $this->artisan(UpdateCommand::class, [
         '--release-notes' => <<<MD
         ### Added
@@ -482,7 +482,7 @@ it('does not add date to release heading if it does not contain a compare url an
         '--latest-version' => 'v1.0.0',
         '--path-to-changelog' => __DIR__ . '/../Stubs/base-changelog-without-unreleased.md',
         '--release-date' => '2021-02-01',
-        '--hide-date' => true,
+        '--hide-release-date' => true,
     ])
         ->expectsOutput(file_get_contents(__DIR__ . '/../Stubs/expected-changelog-without-unreleased-without-date.md'))
         ->assertSuccessful();

--- a/tests/Stubs/expected-changelog-without-date.md
+++ b/tests/Stubs/expected-changelog-without-date.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/org/repo/compare/v1.0.0...HEAD)
+
+Please do not update the unreleased notes.
+
+<!-- Content should be placed here -->
+## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0)
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+
+- Initial Release

--- a/tests/Stubs/expected-changelog-without-unreleased-without-date.md
+++ b/tests/Stubs/expected-changelog-without-unreleased-without-date.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## v1.0.0
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D
+
+## v0.1.0 - 2021-01-01
+
+### Added
+
+- Initial Release

--- a/tests/Unit/CreateNewReleaseHeadingTest.php
+++ b/tests/Unit/CreateNewReleaseHeadingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+
+use App\CreateNewReleaseHeading;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Node\Inline\Text;
+use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
+use Wnx\CommonmarkMarkdownRenderer\Renderer\MarkdownRenderer;
+
+it('creates new release heading ast', function () {
+    $latestVersion = 'v1.0.0';
+    $headingText = $latestVersion;
+    $releaseDate = '2021-02-01';
+
+    $environment = new Environment();
+    $environment->addExtension(new MarkdownRendererExtension());
+    $markdownRenderer = new MarkdownRenderer($environment);
+
+    /** @var Document $result */
+    $result = app(CreateNewReleaseHeading::class)->create(
+        $headingText,
+        $releaseDate,
+        hideDate: false,
+    );
+
+    $document = new Document();
+    $document->appendChild($result);
+
+    $this->assertInstanceOf(Heading::class, $result);
+    $this->assertInstanceOf(Text::class, $result->firstChild());
+
+    $renderedMarkdown = $markdownRenderer->renderDocument($document);
+    $this->assertEquals('## v1.0.0 - 2021-02-01', trim($renderedMarkdown->getContent()));
+});
+
+it('creates new release heading ast without a date if hideDate boolean is true', function () {
+    $latestVersion = 'v1.0.0';
+    $headingText = $latestVersion;
+    $releaseDate = '2021-02-01';
+
+    $environment = new Environment();
+    $environment->addExtension(new MarkdownRendererExtension());
+    $markdownRenderer = new MarkdownRenderer($environment);
+
+    /** @var Document $result */
+    $result = app(CreateNewReleaseHeading::class)->create(
+        $headingText,
+        $releaseDate,
+        hideDate: true,
+    );
+
+    $document = new Document();
+    $document->appendChild($result);
+
+    $this->assertInstanceOf(Heading::class, $result);
+    $this->assertInstanceOf(Text::class, $result->firstChild());
+
+    $renderedMarkdown = $markdownRenderer->renderDocument($document);
+    $this->assertEquals('## v1.0.0', trim($renderedMarkdown->getContent()));
+});

--- a/tests/Unit/CreateNewReleaseHeadingWithCompareUrl.php
+++ b/tests/Unit/CreateNewReleaseHeadingWithCompareUrl.php
@@ -28,7 +28,8 @@ test('creates new release heading ast', function () {
         $previousVersion,
         $latestVersion,
         $headingText,
-        $releaseDate
+        $releaseDate,
+        hideDate: false,
     );
 
     $document = new Document();
@@ -42,4 +43,39 @@ test('creates new release heading ast', function () {
 
     $renderedMarkdown = $markdownRenderer->renderDocument($document);
     $this->assertEquals('## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01', trim($renderedMarkdown->getContent()));
+
+});
+
+it('does not add date to release heading if hideDate is false', function () {
+    $repositoryUrl = 'https://github.com/org/repo';
+    $previousVersion = 'v0.1.0';
+    $latestVersion = 'v1.0.0';
+    $headingText = $latestVersion;
+    $releaseDate = '2021-02-01';
+
+    $environment = new Environment();
+    $environment->addExtension(new MarkdownRendererExtension());
+    $markdownRenderer = new MarkdownRenderer($environment);
+
+    /** @var Document $result */
+    $result = app(CreateNewReleaseHeadingWithCompareUrl::class)->create(
+        $repositoryUrl,
+        $previousVersion,
+        $latestVersion,
+        $headingText,
+        $releaseDate,
+        hideDate: true,
+    );
+
+    $document = new Document();
+    $document->appendChild($result);
+
+    $this->assertInstanceOf(Heading::class, $result);
+    $this->assertInstanceOf(Link::class, $result->firstChild());
+    $this->assertInstanceOf(Text::class, $result->firstChild()->firstChild());
+    $this->assertInstanceOf(Text::class, $result->firstChild()->firstChild());
+
+
+    $renderedMarkdown = $markdownRenderer->renderDocument($document);
+    $this->assertEquals('## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0)', trim($renderedMarkdown->getContent()));
 });


### PR DESCRIPTION
This PR adds a new `--hide-release-date`-option to the CLI. If set to true, the release date will not be added to release headings.
See #36.

Closes #38 

## TODO
- [x] Rename `--hide-date` to `--hide-release-date`