### PR TITLE
Fix get github username pattern

### DIFF
--- a/app/Actions/ParseAndLinkifyGitHubUsernamesAction.php
+++ b/app/Actions/ParseAndLinkifyGitHubUsernamesAction.php
@@ -16,9 +16,9 @@ class ParseAndLinkifyGitHubUsernamesAction
         // - `(?<!\[)` and `(?!\])` are negative lookbehind and lookahead assertions, respectively.
         //   They ensure that the GitHub username is not preceded or followed by a square
         //   bracket [ or ], which indicates that the username is already wrapped in a link.
-        // - `@([A-Za-z0-9_]+)` matches the GitHub username itself. It starts with
+        // - `@([A-Za-z0-9_-]+)` matches the GitHub username itself. It starts with
         //   the @ symbol and consists of alphanumeric characters and underscores.
-        $pattern = '/(?<!\[)@([A-Za-z0-9_]+)(?!\])/';
+        $pattern = '/(?<!\[)@([A-Za-z0-9_-]+)(?!\])/';
 
         $replacement = '[@$1](https://github.com/$1)';
 

--- a/tests/Unit/Actions/ParseAndLinkifyGitHubUsernamesActionTest.php
+++ b/tests/Unit/Actions/ParseAndLinkifyGitHubUsernamesActionTest.php
@@ -24,3 +24,10 @@ it('replaces GitHub usernames with links', function () {
 
     expect($result)->toEqual('This is a string with a [@username](https://github.com/username) in it.');
 });
+
+it('replaces GitHub usernames with links if it contains -', function () {
+
+    $result = app(ParseAndLinkifyGitHubUsernamesAction::class)->execute('This is a string with a @user-name in it.');
+
+    expect($result)->toEqual('This is a string with a [@user-name](https://github.com/user-name) in it.');
+});


### PR DESCRIPTION
The username will contain `-`, which will now generate an error.

see https://github.com/laravel/octane/blob/00f88a713f4a0a56d59dc0f5bc140c4a0df600d5/CHANGELOG.md?plain=1#L8

This PR fixed it.