### PR TITLE
Remove outdated GitHubActions Output Syntax

### DIFF
--- a/app/Support/GitHubActionsOutput.php
+++ b/app/Support/GitHubActionsOutput.php
@@ -17,12 +17,6 @@ class GitHubActionsOutput extends MessageBag
             if ($this->hasGithubOutputEnvironment()) {
                 $this->setOutput($key, $value);
             }
-
-            // Set output variables using old syntax for compatibility with older versions of GitHub Actions runner.
-            // Stops working in 2023.
-            if (now()->year < 2023) {
-                $output->text(sprintf('::set-output name=%s::%s', $key, $value));
-            }
         }
     }
 

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -25,30 +25,6 @@ it('places given release notes in correct position in given markdown changelog',
         ->assertSuccessful();
 });
 
-it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL for GitHub Actions in CI environment', function () {
-    $this->artisan(UpdateCommand::class, [
-        '--release-notes' => <<<'MD'
-        ### Added
-        - New Feature A
-        - New Feature B
-
-        ### Changed
-        - Update Feature C
-
-        ### Removes
-        - Remove Feature D
-        MD,
-        '--latest-version' => 'v1.0.0',
-        '--path-to-changelog' => __DIR__.'/../Stubs/base-changelog.md',
-        '--release-date' => '2021-02-01',
-        '--github-actions-output' => true,
-    ])
-        ->expectsOutputToContain(sprintf('::set-output name=%s::%s', 'RELEASE_COMPARE_URL', 'https://github.com/org/repo/compare/v0.1.0...v1.0.0'))
-        ->expectsOutputToContain(sprintf('::set-output name=%s::%s', 'RELEASE_URL_FRAGMENT', '#v100---2021-02-01'))
-        ->expectsOutputToContain(sprintf('::set-output name=%s::%s', 'UNRELEASED_COMPARE_URL', 'https://github.com/org/repo/compare/v1.0.0...HEAD'))
-        ->assertSuccessful();
-})->skip(fn () => now()->year > 2022);
-
 it('outputs RELEASE_COMPARE_URL and UNRELEASED_COMPARE_URL to GITHUB_OUTPUT environment', function () {
     $this->artisan(UpdateCommand::class, [
         '--release-notes' => <<<'MD'


### PR DESCRIPTION
Remove code related to the deprecated `set-output` command.
(Code has not been executed since the start of 2023).

## Notes
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/