### PR TITLE
Add compare URLs to release headings based on previous release headings when no unreleased heading is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-If your changelog follows the ["Keep a Changelog"](https://keepachangelog.com/) format and contains an "Unreleased"-heading with a link to the repositories compare view, the CLI will automatically update the link in the Unreleased heading.
+If your changelog follows the ["Keep a Changelog"](https://keepachangelog.com/) format and contains an "Unreleased"-heading with a link to the repository compare view, the CLI will automatically update the link in the Unreleased heading.
 
 Here is an example of a changelog, before it is updated with the CLI.
 
@@ -185,6 +185,27 @@ Please do not update the unreleased notes.
 ```
 
 The content between the "Unreleased"-heading and the latest version will remain untouched by the CLI.
+
+---
+
+If you don't have a "Unreleased"-heading in your changelog, but the headings of your previous releases contain a link to the repository compare view, the CLI will add links to the compare view to the added release heading.
+
+```diff
+# Changelog
+
++## [v1.1.0](https://github.com/org/repo/compare/v1.0.0...v1.1.0) - 2021-02-01
++
++### Added
++
++* New Feature A
++* New Feature B
++
+
+## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-01-01
+
+### Added
+* Initial Release
+```
 
 ## Testing
 

--- a/app/Actions/AddReleaseNotesToChangelogAction.php
+++ b/app/Actions/AddReleaseNotesToChangelogAction.php
@@ -51,6 +51,7 @@ class AddReleaseNotesToChangelogAction
                 headingText: $headingText,
                 releaseDate: $releaseDate,
                 releaseNotes: $releaseNotes,
+                compareUrlTargetRevision: $compareUrlTargetRevision,
                 hideDate: $hideDate,
             );
         }

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -42,7 +42,7 @@ class PlaceReleaseNotesAtTheTopAction
         // If the previous version does not contain a URL, don't add a URL to the new release heading
         if ($previousVersionHeading && $this->headingContainsLink($previousVersionHeading)) {
 
-            $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($previousVersionHeading);
+            $previousVersion = $this->getPreviousVersionFromHeading($previousVersionHeading);
             $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($previousVersionHeading);
             $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $headingText, $compareUrlTargetRevision = 'HEAD');
 
@@ -52,14 +52,6 @@ class PlaceReleaseNotesAtTheTopAction
 
             // Create new Heading containing the new version number
             $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $headingText, $headingText, $releaseDate, $hideDate);
-
-
-            // Update Compare URL in Previous Version Heading to use `$headingText` as the target revision in the compare URL
-            $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($previousVersionHeading);
-            $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $previousVersion, $headingText);
-
-            $link = $this->getLinkNodeFromHeading($previousVersionHeading);
-            $link->setUrl($updatedUrl);
         } else {
             $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
         }
@@ -82,14 +74,14 @@ class PlaceReleaseNotesAtTheTopAction
     /**
      * @throws Throwable
      */
-    private function getPreviousVersionFromUnreleasedHeading(Heading $unreleasedHeading): ?string
+    private function getPreviousVersionFromHeading(Heading $heading): ?string
     {
-        $linkNode = $this->getLinkNodeFromHeading($unreleasedHeading);
+        $linkNode = $this->getLinkNodeFromHeading($heading);
 
         return Str::of($linkNode->getUrl())
             ->afterLast('/')
             ->explode('...')
-            ->first();
+            ->last();
     }
 
     /**

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -31,7 +31,7 @@ class PlaceReleaseNotesAtTheTopAction
     /**
      * @throws Throwable
      */
-    public function execute(Document $changelog, string $headingText, string $releaseDate, ?string $releaseNotes, bool $hideDate = false): Document
+    public function execute(Document $changelog, string $headingText, string $releaseDate, ?string $releaseNotes, string $compareUrlTargetRevision, bool $hideDate = false): Document
     {
         throw_if(empty($releaseNotes), ReleaseNotesNotProvidedException::class);
 
@@ -44,7 +44,7 @@ class PlaceReleaseNotesAtTheTopAction
 
             $previousVersion = $this->getPreviousVersionFromHeading($previousVersionHeading);
             $repositoryUrl = $this->getRepositoryUrlFromHeading($previousVersionHeading);
-            $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $headingText, $compareUrlTargetRevision = 'HEAD');
+            $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $headingText, $compareUrlTargetRevision);
 
             $link = clone $this->getLinkNodeFromHeading($previousVersionHeading);
             $link->setUrl($updatedUrl);

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -51,7 +51,7 @@ class PlaceReleaseNotesAtTheTopAction
             $this->gitHubActionsOutput->add('UNRELEASED_COMPARE_URL', $updatedUrl);
 
             // Create new Heading containing the new version number
-            $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $headingText, $headingText, $releaseDate, $hideDate);
+            $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $compareUrlTargetRevision, $headingText, $releaseDate, $hideDate);
         } else {
             $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
         }

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -52,6 +52,14 @@ class PlaceReleaseNotesAtTheTopAction
 
             // Create new Heading containing the new version number
             $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $headingText, $headingText, $releaseDate, $hideDate);
+
+
+            // Update Compare URL in Previous Version Heading to use `$headingText` as the target revision in the compare URL
+            $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($previousVersionHeading);
+            $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $previousVersion, $headingText);
+
+            $link = $this->getLinkNodeFromHeading($previousVersionHeading);
+            $link->setUrl($updatedUrl);
         } else {
             $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
         }

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -43,7 +43,7 @@ class PlaceReleaseNotesAtTheTopAction
         if ($previousVersionHeading && $this->headingContainsLink($previousVersionHeading)) {
 
             $previousVersion = $this->getPreviousVersionFromHeading($previousVersionHeading);
-            $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($previousVersionHeading);
+            $repositoryUrl = $this->getRepositoryUrlFromHeading($previousVersionHeading);
             $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $headingText, $compareUrlTargetRevision = 'HEAD');
 
             $link = clone $this->getLinkNodeFromHeading($previousVersionHeading);
@@ -87,19 +87,19 @@ class PlaceReleaseNotesAtTheTopAction
     /**
      * @throws Throwable
      */
-    private function getRepositoryUrlFromUnreleasedHeading(Heading $unreleasedHeading): string
+    private function getRepositoryUrlFromHeading(Heading $heading): string
     {
-        $linkNode = $this->getLinkNodeFromHeading($unreleasedHeading);
+        $linkNode = $this->getLinkNodeFromHeading($heading);
 
         return Str::of($linkNode->getUrl())
             ->before('/compare')
             ->__toString();
     }
 
-    private function getLinkNodeFromHeading(Heading $unreleasedHeading): Link
+    private function getLinkNodeFromHeading(Heading $heading): Link
     {
         /** @var Link $linkNode */
-        $linkNode = $unreleasedHeading->firstChild();
+        $linkNode = $heading->firstChild();
 
         return $linkNode;
     }

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -46,12 +46,12 @@ class PlaceReleaseNotesAtTheTopAction
             $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($previousVersionHeading);
             $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $headingText, $compareUrlTargetRevision = 'HEAD');
 
-            $link = $this->getLinkNodeFromHeading($previousVersionHeading);
+            $link = clone $this->getLinkNodeFromHeading($previousVersionHeading);
             $link->setUrl($updatedUrl);
             $this->gitHubActionsOutput->add('UNRELEASED_COMPARE_URL', $updatedUrl);
 
             // Create new Heading containing the new version number
-            $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $compareUrlTargetRevision, $headingText, $releaseDate, $hideDate);
+            $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $headingText, $headingText, $releaseDate, $hideDate);
         } else {
             $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
         }

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -38,7 +38,7 @@ class PlaceReleaseNotesAtTheTopAction
         // Find the Heading of the previous Version
         $previousVersionHeading = $this->findFirstSecondLevelHeading->find($changelog);
 
-        // If the previous version heading contains a compare URL, we should use that to generate the new release heading
+        // If the previous version heading contains a URL, we should use that to generate the new release heading
         // If the previous version does not contain a URL, don't add a URL to the new release heading
         if ($previousVersionHeading && $this->headingContainsLink($previousVersionHeading)) {
 
@@ -51,7 +51,7 @@ class PlaceReleaseNotesAtTheTopAction
             $this->gitHubActionsOutput->add('UNRELEASED_COMPARE_URL', $updatedUrl);
 
             // Create new Heading containing the new version number
-            $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $headingText, $headingText, $releaseDate, $hideDate);
+            $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create(repositoryUrl: $repositoryUrl, previousVersion: $previousVersion, latestVersion: $headingText, headingText: $headingText, releaseDate: $releaseDate, hideDate: $hideDate);
         } else {
             $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
         }

--- a/app/Actions/PlaceReleaseNotesAtTheTopAction.php
+++ b/app/Actions/PlaceReleaseNotesAtTheTopAction.php
@@ -5,8 +5,14 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\CreateNewReleaseHeading;
+use App\CreateNewReleaseHeadingWithCompareUrl;
 use App\Exceptions\ReleaseNotesNotProvidedException;
+use App\GenerateCompareUrl;
 use App\Queries\FindFirstSecondLevelHeading;
+use App\Support\GitHubActionsOutput;
+use Illuminate\Support\Str;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Node\Block\Document;
 use Throwable;
 
@@ -15,7 +21,10 @@ class PlaceReleaseNotesAtTheTopAction
     public function __construct(
         private readonly FindFirstSecondLevelHeading $findFirstSecondLevelHeading,
         private readonly CreateNewReleaseHeading $createNewReleaseHeading,
-        private readonly InsertReleaseNotesInChangelogAction $insertReleaseNotesInChangelogAction
+        private readonly InsertReleaseNotesInChangelogAction $insertReleaseNotesInChangelogAction,
+        private readonly CreateNewReleaseHeadingWithCompareUrl $createNewReleaseHeadingWithCompareUrl,
+        private readonly GenerateCompareUrl $generateCompareUrl,
+        private readonly GitHubActionsOutput $gitHubActionsOutput,
     ) {
     }
 
@@ -26,10 +35,26 @@ class PlaceReleaseNotesAtTheTopAction
     {
         throw_if(empty($releaseNotes), ReleaseNotesNotProvidedException::class);
 
-        $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
-
         // Find the Heading of the previous Version
         $previousVersionHeading = $this->findFirstSecondLevelHeading->find($changelog);
+
+        // If the previous version heading contains a compare URL, we should use that to generate the new release heading
+        // If the previous version does not contain a URL, don't add a URL to the new release heading
+        if ($previousVersionHeading && $this->headingContainsLink($previousVersionHeading)) {
+
+            $previousVersion = $this->getPreviousVersionFromUnreleasedHeading($previousVersionHeading);
+            $repositoryUrl = $this->getRepositoryUrlFromUnreleasedHeading($previousVersionHeading);
+            $updatedUrl = $this->generateCompareUrl->generate($repositoryUrl, $headingText, $compareUrlTargetRevision = 'HEAD');
+
+            $link = $this->getLinkNodeFromHeading($previousVersionHeading);
+            $link->setUrl($updatedUrl);
+            $this->gitHubActionsOutput->add('UNRELEASED_COMPARE_URL', $updatedUrl);
+
+            // Create new Heading containing the new version number
+            $newReleaseHeading = $this->createNewReleaseHeadingWithCompareUrl->create($repositoryUrl, $previousVersion, $headingText, $headingText, $releaseDate, $hideDate);
+        } else {
+            $newReleaseHeading = $this->createNewReleaseHeading->create($headingText, $releaseDate, $hideDate);
+        }
 
         return $this->insertReleaseNotesInChangelogAction->execute(
             changelog: $changelog,
@@ -37,5 +62,45 @@ class PlaceReleaseNotesAtTheTopAction
             newReleaseHeading: $newReleaseHeading,
             previousVersionHeading: $previousVersionHeading
         );
+    }
+
+    private function headingContainsLink(Heading $previousVersionHeading): bool
+    {
+        $child = $previousVersionHeading->firstChild();
+
+        return $child instanceof Link;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function getPreviousVersionFromUnreleasedHeading(Heading $unreleasedHeading): ?string
+    {
+        $linkNode = $this->getLinkNodeFromHeading($unreleasedHeading);
+
+        return Str::of($linkNode->getUrl())
+            ->afterLast('/')
+            ->explode('...')
+            ->first();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function getRepositoryUrlFromUnreleasedHeading(Heading $unreleasedHeading): string
+    {
+        $linkNode = $this->getLinkNodeFromHeading($unreleasedHeading);
+
+        return Str::of($linkNode->getUrl())
+            ->before('/compare')
+            ->__toString();
+    }
+
+    private function getLinkNodeFromHeading(Heading $unreleasedHeading): Link
+    {
+        /** @var Link $linkNode */
+        $linkNode = $unreleasedHeading->firstChild();
+
+        return $linkNode;
     }
 }

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -187,6 +187,27 @@ it('uses compare-url-target option in unreleased heading url', function () {
         ->assertSuccessful();
 });
 
+it('uses previous release heading in changelog to build compare url of the most recent release', function () {
+    $this->artisan(UpdateCommand::class, [
+        '--release-notes' => <<<'MD'
+        ### Added
+        - New Feature A
+        - New Feature B
+
+        ### Changed
+        - Update Feature C
+
+        ### Removes
+        - Remove Feature D
+        MD,
+        '--latest-version' => 'v1.0.0',
+        '--path-to-changelog' => __DIR__.'/../Stubs/base-changelog-with-headings-with-compare-url.md',
+        '--release-date' => '2021-02-01',
+    ])
+        ->expectsOutput(file_get_contents(__DIR__.'/../Stubs/expected-changelog-with-headings-with-compare-url.md'))
+        ->assertSuccessful();
+});
+
 it('shows warning if version already exists in the changelog', function () {
     $this->artisan(UpdateCommand::class, [
         '--release-notes' => <<<'MD'

--- a/tests/Stubs/base-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/base-changelog-with-headings-with-compare-url.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...HEAD) - 2021-01-01
+## [v0.1.0](https://github.com/org/repo/compare/v0.0.0...v0.1.0) - 2021-01-01
 
 ### Added
 - Initial Release

--- a/tests/Stubs/base-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/base-changelog-with-headings-with-compare-url.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...HEAD) - 2021-01-01
+
+### Added
+- Initial Release

--- a/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remove Feature D
 
-## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...HEAD) - 2021-01-01
+## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-01-01
 
 ### Added
 

--- a/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
@@ -1,10 +1,11 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0](https://github.com/org/repo/compare/v1.0.0...HEAD) - 2021-01-01
+## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-01-01
 
 ### Added
 

--- a/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
@@ -1,0 +1,25 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [v1.0.0](https://github.com/org/repo/compare/v1.0.0...HEAD) - 2021-01-01
+
+### Added
+
+- New Feature A
+- New Feature B
+
+### Changed
+
+- Update Feature C
+
+### Removes
+
+- Remove Feature D
+
+## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...v0.0.0) - 2021-01-01
+
+### Added
+- Initial Release

--- a/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remove Feature D
 
-## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...v0.0.0) - 2021-01-01
+## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...HEAD) - 2021-01-01
 
 ### Added
+
 - Initial Release

--- a/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remove Feature D
 
-## [v0.1.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-01-01
+## [v0.1.0](https://github.com/org/repo/compare/v0.0.0...v0.1.0) - 2021-01-01
 
 ### Added
 

--- a/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
+++ b/tests/Stubs/expected-changelog-with-headings-with-compare-url.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-01-01
+## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
 
 ### Added
 

--- a/tests/Unit/CreateNewReleaseHeadingWithCompareUrlTest.php
+++ b/tests/Unit/CreateNewReleaseHeadingWithCompareUrlTest.php
@@ -20,6 +20,7 @@ test('creates new release heading ast', function () {
 
     $environment = new Environment();
     $environment->addExtension(new MarkdownRendererExtension());
+
     $markdownRenderer = new MarkdownRenderer($environment);
 
     /** @var Document $result */
@@ -54,6 +55,7 @@ it('does not add date to release heading if hideDate is false', function () {
 
     $environment = new Environment();
     $environment->addExtension(new MarkdownRendererExtension());
+
     $markdownRenderer = new MarkdownRenderer($environment);
 
     /** @var Document $result */

--- a/tests/Unit/GenerateCompareUrlTest.php
+++ b/tests/Unit/GenerateCompareUrlTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\GenerateCompareUrl;
+
+it('creates a new compare URL based on the given repository URL, previous version, and latest version', function (string $url, string $from, string $to, string $expected) {
+    $generateCompareUrl = app(GenerateCompareUrl::class);
+    $result = $generateCompareUrl->generate($url, $from, $to);
+
+    expect($result)->toEqual($expected);
+
+})->with([
+    [
+        'url' => 'https://github.com/org/repo',
+        'from' => 'v1.0.0',
+        'to' => 'HEAD',
+        'expected' => 'https://github.com/org/repo/compare/v1.0.0...HEAD',
+    ],
+    [
+        'url' => 'https://github.com/org/repo/',
+        'from' => 'v1.0.0',
+        'to' => 'HEAD',
+        'expected' => 'https://github.com/org/repo/compare/v1.0.0...HEAD',
+    ],
+    [
+        'url' => 'https://example.com',
+        'from' => 'v1.0.0',
+        'to' => 'HEAD',
+        'expected' => 'https://example.com/compare/v1.0.0...HEAD',
+    ],
+    [
+        'url' => 'https://example.com/',
+        'from' => 'v1.0.0',
+        'to' => 'HEAD',
+        'expected' => 'https://example.com/compare/v1.0.0...HEAD',
+    ],
+]);


### PR DESCRIPTION
This PR adds a new feature to the CLI, to build compare URLs even if no "Unreleased" heading is available.

The CLI checks the previous release heading. If it contains an URL and the URL is a GitHub compare URL, the CLI uses these values to build the new release heading.
The URL of the previous heading is updated, so the URL points to the latest release.

## TODOs

- [x] Add Tests
- [ ] ~~Add Test for when URL is not a compare URL~~
- [ ] ~~Improve implementation~~