### PR TITLE
Use Commonmark Mention-Extension to parse GitHub usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Optional. Tell the CLI explicitly to use the content between an "Unreleased Head
 ### `--hide-release-date`
 Optional. Don't add the release date to the release heading.
 
-### `--parse-github-usernames` (experimental 🧪)
+### `--parse-github-usernames`
 Optional. Look for GitHub usernames in `--release-notes` and linkify them. Currently not supported for release notes that are located in the existing changelog.
 
 ```diff

--- a/app/Commands/UpdateCommand.php
+++ b/app/Commands/UpdateCommand.php
@@ -27,7 +27,7 @@ class UpdateCommand extends Command
         {--compare-url-target-revision=HEAD : Target revision used in the compare URL of possible "Unreleased" heading.}
         {--github-actions-output : Display GitHub Actions related output}
         {--hide-release-date : Hide release date in the new release heading.}
-        {--parse-github-usernames : Experimental: Find GitHub usernames in release notes and link to their profile.}
+        {--parse-github-usernames : Find GitHub usernames in release notes and link to their profile.}
         {--w|write : Write changes to file}
     ';
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,8 +6,6 @@ namespace App\Providers;
 
 use App\Support\GitHubActionsOutput;
 use Illuminate\Support\ServiceProvider;
-use League\CommonMark\Environment\Environment;
-use League\CommonMark\Extension\Mention\MentionExtension;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,27 +17,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->singleton(GitHubActionsOutput::class, fn () => new GitHubActionsOutput());
-
-        $this->app->bind(Environment::class, function () {
-            $config = [
-                'mentions' => [
-                    // GitHub handler mention configuration.
-                    // Sample Input:  `@colinodell`
-                    // Sample Output: `<a href="https://www.github.com/colinodell">@colinodell</a>`
-                    'github_handle' => [
-                        'prefix' => '@',
-                        'pattern' => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
-                        'generator' => 'https://github.com/%s',
-                    ],
-                ],
-            ];
-
-            $environment = new Environment($config);
-
-            $environment->addExtension(new MentionExtension());
-
-            return $environment;
-        });
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,8 @@ namespace App\Providers;
 
 use App\Support\GitHubActionsOutput;
 use Illuminate\Support\ServiceProvider;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\Mention\MentionExtension;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -17,6 +19,27 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->singleton(GitHubActionsOutput::class, fn () => new GitHubActionsOutput());
+
+        $this->app->bind(Environment::class, function () {
+            $config = [
+                'mentions' => [
+                    // GitHub handler mention configuration.
+                    // Sample Input:  `@colinodell`
+                    // Sample Output: `<a href="https://www.github.com/colinodell">@colinodell</a>`
+                    'github_handle' => [
+                        'prefix' => '@',
+                        'pattern' => '[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)',
+                        'generator' => 'https://github.com/%s',
+                    ],
+                ],
+            ];
+
+            $environment = new Environment($config);
+
+            $environment->addExtension(new MentionExtension());
+
+            return $environment;
+        });
     }
 
     /**

--- a/tests/Feature/UpdateCommandTest.php
+++ b/tests/Feature/UpdateCommandTest.php
@@ -499,7 +499,7 @@ it('parses github usernames and links to their github user profiles', function (
         - Remove Feature D
         MD,
         '--latest-version' => 'v1.0.0',
-        '--path-to-changelog' => __DIR__.'/../Stubs/base-changelog.md',
+        '--path-to-changelog' => __DIR__.'/../Stubs/base-changelog-with-github-usernames.md',
         '--release-date' => '2021-02-01',
         '--parse-github-usernames' => true,
     ])

--- a/tests/Stubs/base-changelog-with-github-usernames.md
+++ b/tests/Stubs/base-changelog-with-github-usernames.md
@@ -1,32 +1,16 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/org/repo/compare/v1.0.0...HEAD)
+## [Unreleased](https://github.com/org/repo/compare/v0.1.0...HEAD)
 
 Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
-## [v1.0.0](https://github.com/org/repo/compare/v0.1.0...v1.0.0) - 2021-02-01
-
-### Added
-
-- New Feature A [@stefanzweifel](https://github.com/stefanzweifel)
-- New Feature B [@stefanzweifel](https://github.com/stefanzweifel)
-
-### Changed
-
-- Update Feature C
-
-### Removes
-
-- Remove Feature D
 
 ## v0.1.0 - 2021-01-01
 
 ### Added
-
 - Initial Release @stefanzweifel

--- a/tests/Unit/Actions/ParseAndLinkifyGitHubUsernamesActionTest.php
+++ b/tests/Unit/Actions/ParseAndLinkifyGitHubUsernamesActionTest.php
@@ -32,9 +32,9 @@ it('replaces GitHub usernames with links if it contains -', function () {
     expect($result)->toEqual('This is a string with a [@user-name](https://github.com/user-name) in it.');
 });
 
-it('replaces GitHub usernames with links if it contains _', function () {
+it('does not replace GitHub usernames with links if it contains _', function () {
 
     $result = app(ParseAndLinkifyGitHubUsernamesAction::class)->execute('This is a string with a @user_name in it.');
 
-    expect($result)->toEqual('This is a string with a [@user_name](https://github.com/user_name) in it.');
+    expect($result)->toEqual('This is a string with a @user_name in it.');
 });


### PR DESCRIPTION
This PR updates the CLI to use the [MentionExtension](https://commonmark.thephpleague.com/2.4/extensions/mentions/) to parse GitHub usernames in release notes.

## TODOs

- [x] Remove experimental flag
- [ ] ~~Try to add support for the feature for existing release notes as well~~ Adding the extension globally would also update existing release-notes. Not what I want for this release.
- [x] Write tests to ensure existing release notes are not affected by this change