### PR TITLE
Unable to open an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
     - name: Ask a question
       url: https://github.com/stefanzweifel/php-changelog-updater/discussions/new?category=q-a
@@ -6,6 +6,3 @@ contact_links:
     - name: Request a feature
       url: https://github.com/stefanzweifel/php-changelog-updater/discussions/new?category=ideas
       about: Share ideas for new features
-    - name: Report a bug
-      url: https://github.com/stefanzweifel/php-changelog-updater/issues/new
-      about: Report a reproducable bug


### PR DESCRIPTION
## Description

I was attempting to open an issue, but was presented with an infinite loop. That link just leads me back to the menu to big feature/bug/discussion/etc.

I don't really care if this is merged, but since I couldn't open an issue, this was the only way to get in contact, haha.

## Problem

I can create an issue after this is resolved, but for now I'll say, I am using your changelog update action, which uses this CLI.

I believe that the CLI is changing random pieces of the markdown, causing some rendering issues on our end. In most spots, its just removing new lines, for example the following change might happen

This

```markdown
## hi

how are you

# another one, squished together
```

turns into this

```markdown
## hi

how are you
# another one, squished together
```

And the spot that is most troublesome is with details/summary tags

This will remove some newlines, breaking the rendering in github

```markdown
## Other

<details>
<summary>collapsed</summary>

- foo
- bar
- baz

</details>

## last one
```

into this

```markdown
## Other

<details>
<summary>collapsed</summary>
- foo
- bar
- baz
- 
</details>
## last one
```

If the proper new lines are there, github will render the inside of the details tag as markdown. But also, removing the new line between the end tag and the level 2 heading makes the heading not render